### PR TITLE
Change onnxruntime requirement to gpu version and update VAD to run on gpu

### DIFF
--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -251,13 +251,13 @@ class SileroVADModel:
             ) from e
 
         opts = onnxruntime.SessionOptions()
-        opts.inter_op_num_threads = 1
-        opts.intra_op_num_threads = 1
         opts.log_severity_level = 4
+        opts.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_BASIC
+        # https://github.com/microsoft/onnxruntime/issues/11548#issuecomment-1158314424
 
         self.session = onnxruntime.InferenceSession(
             path,
-            providers=["CPUExecutionProvider"],
+            providers=["CUDAExecutionProvider"],
             sess_options=opts,
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ av==10.*
 ctranslate2>=3.17,<4
 huggingface_hub>=0.13
 tokenizers>=0.13,<0.15
-onnxruntime>=1.14,<2
+onnxruntime-gpu>=1.16.0,<2


### PR DESCRIPTION
See discussions here: https://github.com/pyannote/pyannote-audio/issues/1481, https://github.com/guillaumekln/faster-whisper/issues/493, https://github.com/guillaumekln/faster-whisper/issues/364#issuecomment-1645272083

This pull requests lets the VAD run on gpu using `onnxruntime-gpu` rather than `onnxruntime`. There are some issues when depending on both packages: it will default to the cpu version if both are installed. This is mostly a problem when running faster-whisper in conjunction with [pyannote.audio](https://github.com/pyannote/pyannote-audio) (or other libraries that specifically need to run on gpu using `onnxruntime-gpu`).