### PR TITLE
Add support for large-v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,16 +185,16 @@ Here is a non exhaustive list of open-source projects using faster-whisper. Feel
 
 ## Model conversion
 
-When loading a model from its size such as `WhisperModel("large-v2")`, the correspondig CTranslate2 model is automatically downloaded from the [Hugging Face Hub](https://huggingface.co/guillaumekln).
+When loading a model from its size such as `WhisperModel("large-v3")`, the correspondig CTranslate2 model is automatically downloaded from the [Hugging Face Hub](https://huggingface.co/guillaumekln).
 
 We also provide a script to convert any Whisper models compatible with the Transformers library. They could be the original OpenAI models or user fine-tuned models.
 
-For example the command below converts the [original "large-v2" Whisper model](https://huggingface.co/openai/whisper-large-v2) and saves the weights in FP16:
+For example the command below converts the [original "large-v3" Whisper model](https://huggingface.co/openai/whisper-large-v3) and saves the weights in FP16:
 
 ```bash
-pip install transformers[torch]>=4.23
+pip install transformers[torch]>=4.35.0
 
-ct2-transformers-converter --model openai/whisper-large-v2 --output_dir whisper-large-v2-ct2 \
+ct2-transformers-converter --model openai/whisper-large-v3 --output_dir whisper-large-v3-ct2 \
     --copy_files tokenizer.json --quantization float16
 ```
 
@@ -207,12 +207,12 @@ Models can also be converted from the code. See the [conversion API](https://ope
 
 1. Directly load the model from a local directory:
 ```python
-model = faster_whisper.WhisperModel("whisper-large-v2-ct2")
+model = faster_whisper.WhisperModel("whisper-large-v3-ct2")
 ```
 
 2. [Upload your model to the Hugging Face Hub](https://huggingface.co/docs/transformers/model_sharing#upload-with-the-web-interface) and load it from its name:
 ```python
-model = faster_whisper.WhisperModel("username/whisper-large-v2-ct2")
+model = faster_whisper.WhisperModel("username/whisper-large-v3-ct2")
 ```
 
 ## Comparing performance against other implementations

--- a/faster_whisper/tokenizer.py
+++ b/faster_whisper/tokenizer.py
@@ -84,7 +84,10 @@ class Tokenizer:
         return sequence
 
     def encode(self, text: str) -> List[int]:
-        return self.tokenizer.encode(text, add_special_tokens=False).ids
+        result = self.tokenizer.encode(text, add_special_tokens=False)
+        if isinstance(result, list):  # large-v3
+            return result
+        return result.ids
 
     def decode(self, tokens: List[int]) -> str:
         text_tokens = [token for token in tokens if token < self.eot]

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -132,6 +132,7 @@ class WhisperModel:
             intra_threads=cpu_threads,
             inter_threads=num_workers,
         )
+        is_large_v3 = "large-v3" in model_size_or_path  # TODO: check by inspecting `self.model` instead?
 
         tokenizer_file = os.path.join(model_path, "tokenizer.json")
         if os.path.isfile(tokenizer_file):
@@ -141,7 +142,7 @@ class WhisperModel:
                 "openai/whisper-tiny" + ("" if self.model.is_multilingual else ".en")
             )
 
-        self.feature_extractor = FeatureExtractor()
+        self.feature_extractor = FeatureExtractor(feature_size=80 if not is_large_v3 else 128)
         self.num_samples_per_token = self.feature_extractor.hop_length * 2
         self.frames_per_second = (
             self.feature_extractor.sampling_rate // self.feature_extractor.hop_length

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -91,24 +91,23 @@ class WhisperModel:
         """Initializes the Whisper model.
 
         Args:
-          model_size_or_path: Size of the model to use (tiny, tiny.en, base, base.en,
-            small, small.en, medium, medium.en, large-v1, large-v2, or large), a path to a converted
-            model directory, or a CTranslate2-converted Whisper model ID from the Hugging Face Hub.
-            When a size or a model ID is configured, the converted model is downloaded
-            from the Hugging Face Hub.
+          model_size_or_path: Size of the model to use (tiny, tiny.en, base, base.en, small, small.en, medium,
+            medium.en, large-v1, large-v2 (same as large), or large-v3), a path to a converted model directory, or a
+            CTranslate2-converted Whisper model ID from the Hugging Face Hub.  When a size or a model ID is configured,
+            the converted model is downloaded from the Hugging Face Hub.
           device: Device to use for computation ("cpu", "cuda", "auto").
           device_index: Device ID to use.
-            The model can also be loaded on multiple GPUs by passing a list of IDs
-            (e.g. [0, 1, 2, 3]). In that case, multiple transcriptions can run in parallel
-            when transcribe() is called from multiple Python threads (see also num_workers).
+            The model can also be loaded on multiple GPUs by passing a list of IDs (e.g. [0, 1, 2, 3]). In that case,
+            multiple transcriptions can run in parallel when transcribe() is called from multiple Python threads (see
+            also num_workers).
           compute_type: Type to use for computation.
             See https://opennmt.net/CTranslate2/quantization.html.
           cpu_threads: Number of threads to use when running on CPU (4 by default).
             A non zero value overrides the OMP_NUM_THREADS environment variable.
           num_workers: When transcribe() is called from multiple Python threads,
-            having multiple workers enables true parallelism when running the model
-            (concurrent calls to self.model.generate() will run in parallel).
-            This can improve the global throughput at the cost of increased memory usage.
+            having multiple workers enables true parallelism when running the model (concurrent calls to
+            self.model.generate() will run in parallel).  This can improve the global throughput at the cost of
+            increased memory usage.
           download_root: Directory where the models should be saved. If not set, the models
             are saved in the standard Hugging Face cache directory.
           local_files_only:  If True, avoid downloading the file and return the path to the

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -91,23 +91,24 @@ class WhisperModel:
         """Initializes the Whisper model.
 
         Args:
-          model_size_or_path: Size of the model to use (tiny, tiny.en, base, base.en, small, small.en, medium,
-            medium.en, large-v1, large-v2 (same as large), or large-v3), a path to a converted model directory, or a
-            CTranslate2-converted Whisper model ID from the Hugging Face Hub.  When a size or a model ID is configured,
-            the converted model is downloaded from the Hugging Face Hub.
+          model_size_or_path: Size of the model to use (tiny, tiny.en, base, base.en, small,
+            small.en, medium, medium.en, large-v1, large-v2 (same as large), or large-v3), a path
+            to a converted model directory, or a CTranslate2-converted Whisper model ID from the
+            Hugging Face Hub.  When a size or a model ID is configured, the converted model is
+            downloaded from the Hugging Face Hub.
           device: Device to use for computation ("cpu", "cuda", "auto").
           device_index: Device ID to use.
-            The model can also be loaded on multiple GPUs by passing a list of IDs (e.g. [0, 1, 2, 3]). In that case,
-            multiple transcriptions can run in parallel when transcribe() is called from multiple Python threads (see
-            also num_workers).
+            The model can also be loaded on multiple GPUs by passing a list of IDs (e.g. [0, 1, 2,
+            3]). In that case, multiple transcriptions can run in parallel when transcribe() is
+            called from multiple Python threads (see also num_workers).
           compute_type: Type to use for computation.
             See https://opennmt.net/CTranslate2/quantization.html.
           cpu_threads: Number of threads to use when running on CPU (4 by default).
             A non zero value overrides the OMP_NUM_THREADS environment variable.
           num_workers: When transcribe() is called from multiple Python threads,
-            having multiple workers enables true parallelism when running the model (concurrent calls to
-            self.model.generate() will run in parallel).  This can improve the global throughput at the cost of
-            increased memory usage.
+            having multiple workers enables true parallelism when running the model (concurrent
+            calls to self.model.generate() will run in parallel).  This can improve the global
+            throughput at the cost of increased memory usage.
           download_root: Directory where the models should be saved. If not set, the models
             are saved in the standard Hugging Face cache directory.
           local_files_only:  If True, avoid downloading the file and return the path to the
@@ -132,25 +133,33 @@ class WhisperModel:
             intra_threads=cpu_threads,
             inter_threads=num_workers,
         )
-        is_large_v3 = "large-v3" in model_size_or_path  # TODO: check by inspecting `self.model` instead?
+        # TODO: check if it's large-v3 by inspecting `self.model` instead?
+        is_large_v3 = "large-v3" in model_size_or_path
 
         tokenizer_file = os.path.join(model_path, "tokenizer.json")
         if os.path.isfile(tokenizer_file):
             self.hf_tokenizer = tokenizers.Tokenizer.from_file(tokenizer_file)
         else:
             if is_large_v3:
-                # Tokenizer for large-v3 is different, so we need to load as in whisper-large-v3 and monkey patch it to
-                # have the `token_to_id` method.
+                # Tokenizer for large-v3 is different, so we need to load as in whisper-large-v3
+                # and monkey patch it to have the `token_to_id` method.
+                # TODO: load the new tokenizer without requiring `transformers`
                 from transformers import AutoProcessor
 
-                self.hf_tokenizer = AutoProcessor.from_pretrained("openai/whisper-large-v3").tokenizer
-                self.hf_tokenizer.token_to_id = lambda token: self.hf_tokenizer.convert_tokens_to_ids(token)
+                processor = AutoProcessor.from_pretrained("openai/whisper-large-v3")
+                self.hf_tokenizer = processor.tokenizer
+                self.hf_tokenizer.token_to_id = (
+                    lambda token: self.hf_tokenizer.convert_tokens_to_ids(token)
+                )
             else:
                 self.hf_tokenizer = tokenizers.Tokenizer.from_pretrained(
-                    "openai/whisper-tiny" + ("" if self.model.is_multilingual else ".en")
+                    "openai/whisper-tiny"
+                    + ("" if self.model.is_multilingual else ".en")
                 )
 
-        self.feature_extractor = FeatureExtractor(feature_size=80 if not is_large_v3 else 128)
+        self.feature_extractor = FeatureExtractor(
+            feature_size=80 if not is_large_v3 else 128
+        )
         self.num_samples_per_token = self.feature_extractor.hop_length * 2
         self.frames_per_second = (
             self.feature_extractor.sampling_rate // self.feature_extractor.hop_length

--- a/faster_whisper/utils.py
+++ b/faster_whisper/utils.py
@@ -20,6 +20,7 @@ _MODELS = {
     "medium": "guillaumekln/faster-whisper-medium",
     "large-v1": "guillaumekln/faster-whisper-large-v1",
     "large-v2": "guillaumekln/faster-whisper-large-v2",
+    "large-v3": "turicas/faster-whisper-large-v3",
     "large": "guillaumekln/faster-whisper-large-v2",
 }
 

--- a/requirements.conversion.txt
+++ b/requirements.conversion.txt
@@ -1,1 +1,1 @@
-transformers[torch]>=4.23
+transformers[torch]>=4.35.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 av==10.*
-ctranslate2>=3.17,<4
+ctranslate2>=3.21.0,<4
 huggingface_hub>=0.13
 tokenizers>=0.13,<0.15
 onnxruntime>=1.14,<2


### PR DESCRIPTION
In summary:

- Upgrade ctranslate2 and transformers
- Add large-v3 to the list of models (currently using [turicas/faster-whisper-large-v3](https://huggingface.co/turicas/faster-whisper-large-v3))
- Fix feature_size (n_mels) for large-v3
- Change tokenizer to be compatible with large-v3 (the older cannot be used, tokens like `transcribe` and `translate` were changed)
- Update README

Note: I'm not sure if the way I've implemented is the best one, feel free to give feedbacks. =) One of the things that can be optimized is the loading of the new tokenizer, which requires the `transformers` library when using `large-v3`.