### PR TITLE
Force read-mode in `av.open`

### DIFF
--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -43,7 +43,7 @@ def decode_audio(
     raw_buffer = io.BytesIO()
     dtype = None
 
-    with av.open(input_file, metadata_errors="ignore") as container:
+    with av.open(input_file, mode="r", metadata_errors="ignore") as container:
         frames = container.decode(audio=0)
         frames = _ignore_invalid_frames(frames)
         frames = _group_frames(frames, 500000)


### PR DESCRIPTION
The `av.open` functions checks input metadata to determine the mode to open with ("r" or "w"). If an input to `decode_audio` is found to be in write-mode, it will fail. Forcing read mode solves this.

I encountered this in a FastAPI application, where I used the `UploadFile` type to accept a file in my API endpoint. This uses a `SpooledTemporaryFile` underneath. In some circumstances, such as with small input files, this spooled file will have mode "w+b" when we first attempt to read it, causing `decode_audio` to try opening with `av.open` in write mode, and failing. Forcing to read-mode fixes this.

It would not make sense for `av.open` in `decode_audio` to ever use write-mode, so this should not negatively impact any other uses.