### PR TITLE
Bugfix: Illogical "Avoid computing higher temperatures on no_speech"

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -721,6 +721,7 @@ class WhisperModel:
             if (
                 options.no_speech_threshold is not None
                 and result.no_speech_prob > options.no_speech_threshold
+                and options.log_prob_threshold is not None
                 and avg_logprob < options.log_prob_threshold
             ):
                 needs_fallback = False  # silence

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -721,6 +721,7 @@ class WhisperModel:
             if (
                 options.no_speech_threshold is not None
                 and result.no_speech_prob > options.no_speech_threshold
+                and avg_logprob < options.log_prob_threshold
             ):
                 needs_fallback = False  # silence
 


### PR DESCRIPTION
Fixing: https://github.com/SYSTRAN/faster-whisper/issues/621
Regression since PR: https://github.com/SYSTRAN/faster-whisper/pull/225

**The bug**: It's "silence" when decoding has failed due to `compression_ratio_threshold` [+no_speech_threshold] in https://github.com/SYSTRAN/faster-whisper/pull/225, when further down the code it's not "silence" anymore.

"Silence" should be only when decoding has failed due to `log_prob_threshold`  [+no_speech_threshold].
As described there:
https://github.com/SYSTRAN/faster-whisper/blob/44f7e589478866546bfcd1d105e254a74e2caad5/faster_whisper/transcribe.py#L239-L241

The bug opens the gates for the hallucination loops.