### PR TITLE
Bumps up PyAV version to support Python 3.12.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-av==10.*
+av==11.*
 ctranslate2>=3.22,<4
 huggingface_hub>=0.13
 tokenizers>=0.13,<0.16


### PR DESCRIPTION
Fix for https://github.com/SYSTRAN/faster-whisper/issues/677 https://github.com/SYSTRAN/faster-whisper/issues/678 https://github.com/SYSTRAN/faster-whisper/issues/571

Bumps up PyAV version to support Python 3.12.x