### PR TITLE
Upgrade ctranslate2 version to support CUDA 12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 av==10.*
-ctranslate2>=3.22,<4
+ctranslate2>=4.0,<5
 huggingface_hub>=0.13
 tokenizers>=0.13,<0.16
 onnxruntime>=1.14,<2


### PR DESCRIPTION
Upgrade ctranslate2 version to support CUDA 12.
For more information: https://github.com/OpenNMT/CTranslate2/releases/tag/v4.0.0