### PR TITLE
Update logic to get segment from features before encoding

### DIFF
--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -102,3 +102,18 @@ def _resample_frames(frames, resampler):
     # Add None to flush the resampler.
     for frame in itertools.chain(frames, [None]):
         yield from resampler.resample(frame)
+
+
+def pad_or_trim(array, length: int, *, axis: int = -1):
+    """
+    Pad or trim the audio array to N_SAMPLES, as expected by the encoder.
+    """
+    if array.shape[axis] > length:
+        array = array.take(indices=range(length), axis=axis)
+
+    if array.shape[axis] < length:
+        pad_widths = [(0, 0)] * array.ndim
+        pad_widths[axis] = (0, length - array.shape[axis])
+        array = np.pad(array, pad_widths)
+
+    return array

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -11,7 +11,7 @@ import ctranslate2
 import numpy as np
 import tokenizers
 
-from faster_whisper.audio import decode_audio
+from faster_whisper.audio import decode_audio, pad_or_trim
 from faster_whisper.feature_extractor import FeatureExtractor
 from faster_whisper.tokenizer import _LANGUAGE_CODES, Tokenizer
 from faster_whisper.utils import download_model, format_timestamp, get_end, get_logger
@@ -492,6 +492,7 @@ class WhisperModel:
             )
             segment = features[:, seek : seek + segment_size]
             segment_duration = segment_size * self.feature_extractor.time_per_frame
+            segment = pad_or_trim(segment, self.feature_extractor.nb_max_frames)
 
             if self.logger.isEnabledFor(logging.DEBUG):
                 self.logger.debug(


### PR DESCRIPTION
Quick fix for https://github.com/SYSTRAN/faster-whisper/pull/646

I tested with a poor quality audio file (192s) and received:
- `ctranslate2==3.24.0` and `faster-whisper==0.10.1`,  the execution time is 12.9s
- `ctranslate2==3.24.0` and `faster-whisper==1.0.1`,  the execution time is 28.9s

Below is my testing code:
```python
model = WhisperModel('large-v3', device='cuda')
segments, info = model.transcribe(jfk_path, word_timestamps=True)
```

After investigating, I found that the logic changes below increased the latency:
Old logic:
```python
segment = features[:, seek : seek + self.feature_extractor.nb_max_frames]
segment_size = min(
    self.feature_extractor.nb_max_frames, content_frames - seek
)
``` 
New update logic in https://github.com/SYSTRAN/faster-whisper/pull/646:
```python
segment_size = min(
    self.feature_extractor.nb_max_frames,
    content_frames - seek,
    seek_clip_end - seek,
)
segment = features[:, seek : seek + segment_size]
```
Cutting the segment like this changed the `encode_output` and it only happens at the last loop because then `segment_size  <  self.feature_extractor.nb_max_frames`.
So the `decode_result` also changed and it's quality is reduced in my tests.
Specifically, I got the following error in my log:
```
Compression ratio threshold is not met with temperature 0.0 (3.9903846153846154 > 2.4)
Compression ratio threshold is not met with temperature 0.2 (3.9903846153846154 > 2.4)
Compression ratio threshold is not met with temperature 0.4 (3.9903846153846154 > 2.4)
Compression ratio threshold is not met with temperature 0.6 (3.7184466019417477 > 2.4)
```
=> The quality of `decode_result` is poor and repetitive so it takes more iterations to decode and export final result, leading to increased transcription time.
For more info, you can check this [logic](https://github.com/SYSTRAN/faster-whisper/blob/master/faster_whisper/transcribe.py#L852).
