### PR TITLE
Feature/add hotwords

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -906,13 +906,13 @@ class WhisperModel:
     ) -> List[int]:
         prompt = []
 
-        if hotwords and not prefix:
-            hotwords_tokens = tokenizer.encode(" " + hotwords.strip())
-            if len(hotwords_tokens) >= self.max_length // 2:
-                hotwords_tokens = hotwords_tokens[: self.max_length // 2 - 1]
-            prompt.extend(hotwords_tokens)
         if previous_tokens:
             prompt.append(tokenizer.sot_prev)
+            if hotwords and not prefix:
+                hotwords_tokens = tokenizer.encode(" " + hotwords.strip())
+                if len(hotwords_tokens) >= self.max_length // 2:
+                    hotwords_tokens = hotwords_tokens[: self.max_length // 2 - 1]
+                prompt.extend(hotwords_tokens)
             prompt.extend(previous_tokens[-(self.max_length // 2 - 1) :])
 
         prompt.extend(tokenizer.sot_sequence)

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -499,7 +499,7 @@ class WhisperModel:
                     "Processing segment at %s", format_timestamp(time_offset)
                 )
 
-            previous_tokens = all_tokens[prompt_reset_since:]
+            previous_tokens = all_tokens[prompt_reset_since:]            
             prompt = self.get_prompt(
                 tokenizer,
                 previous_tokens,
@@ -899,9 +899,11 @@ class WhisperModel:
         prefix: Optional[str] = None,
     ) -> List[int]:
         prompt = []
-
         if previous_tokens:
             prompt.append(tokenizer.sot_prev)
+            hotwords = "this video is about ComfyUI"
+            hotwords_token = tokenizer.encode(hotwords)
+            prompt.extend(hotwords_token)
             prompt.extend(previous_tokens[-(self.max_length // 2 - 1) :])
 
         prompt.extend(tokenizer.sot_sequence)

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -221,7 +221,7 @@ class WhisperModel:
         chunk_length: Optional[int] = None,
         clip_timestamps: Union[str, List[float]] = "0",
         hallucination_silence_threshold: Optional[float] = None,
-        hotwords : Optional[str] = None
+        hotwords: Optional[str] = None,
     ) -> Tuple[Iterable[Segment], TranscriptionInfo]:
         """Transcribes an input file.
 
@@ -402,7 +402,7 @@ class WhisperModel:
             max_new_tokens=max_new_tokens,
             clip_timestamps=clip_timestamps,
             hallucination_silence_threshold=hallucination_silence_threshold,
-            hotwords=hotwords
+            hotwords=hotwords,
         )
 
         segments = self.generate_segments(features, tokenizer, options, encoder_output)
@@ -503,13 +503,13 @@ class WhisperModel:
                     "Processing segment at %s", format_timestamp(time_offset)
                 )
 
-            previous_tokens = all_tokens[prompt_reset_since:]            
+            previous_tokens = all_tokens[prompt_reset_since:]
             prompt = self.get_prompt(
                 tokenizer,
                 previous_tokens,
                 without_timestamps=options.without_timestamps,
                 prefix=options.prefix if seek == 0 else None,
-                hotwords = options.hotwords
+                hotwords=options.hotwords,
             )
 
             if seek > 0 or encoder_output is None:
@@ -902,7 +902,7 @@ class WhisperModel:
         previous_tokens: List[int],
         without_timestamps: bool = False,
         prefix: Optional[str] = None,
-        hotwords:Optional[str] = None
+        hotwords: Optional[str] = None,
     ) -> List[int]:
         prompt = []
 

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -905,6 +905,12 @@ class WhisperModel:
         hotwords:Optional[str] = None
     ) -> List[int]:
         prompt = []
+
+        if hotwords and not prefix:
+            hotwords_tokens = tokenizer.encode(" " + hotwords.strip())
+            if len(hotwords_tokens) >= self.max_length // 2:
+                hotwords_tokens = hotwords_tokens[: self.max_length // 2 - 1]
+            prompt.extend(hotwords_tokens)
         if previous_tokens:
             prompt.append(tokenizer.sot_prev)
             prompt.extend(previous_tokens[-(self.max_length // 2 - 1) :])
@@ -921,12 +927,6 @@ class WhisperModel:
             if not without_timestamps:
                 prompt.append(tokenizer.timestamp_begin)
             prompt.extend(prefix_tokens)
-
-        if hotwords and not prefix:
-            hotwords_tokens = tokenizer.encode(" " + hotwords.strip())
-            if len(hotwords_tokens) >= self.max_length // 2:
-                hotwords_tokens = hotwords_tokens[: self.max_length // 2 - 1]
-            prompt.extend(hotwords_tokens)
 
         return prompt
 

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -906,14 +906,15 @@ class WhisperModel:
     ) -> List[int]:
         prompt = []
 
-        if previous_tokens:
+        if previous_tokens or (hotwords and not prefix):
             prompt.append(tokenizer.sot_prev)
             if hotwords and not prefix:
                 hotwords_tokens = tokenizer.encode(" " + hotwords.strip())
                 if len(hotwords_tokens) >= self.max_length // 2:
                     hotwords_tokens = hotwords_tokens[: self.max_length // 2 - 1]
                 prompt.extend(hotwords_tokens)
-            prompt.extend(previous_tokens[-(self.max_length // 2 - 1) :])
+            if previous_tokens:
+                prompt.extend(previous_tokens[-(self.max_length // 2 - 1) :])
 
         prompt.extend(tokenizer.sot_sequence)
 


### PR DESCRIPTION
hello!
During the transcription process, I often encounter some proprietary or new vocabulary, and Whisper cannot handle it well. I searched for solutions, and the community provided two options:

Fine-tuning the model: This approach is costly, and it's not practical to fine-tune the model every time a new term emerges.

Using initial_prompt: However, initial_prompt only applies to the first window. If specialized terms don't appear at the beginning, this method is ineffective.

Upon reviewing other transcription models, it's common practice to use hotwords. So, I implemented this feature. My approach is to add hotword-related prompts before each transcription window. Since there's a maximum length limit, I occupy the space previously used by the prefix. When the prefix isn't set, hotwords take effect. After testing, it indeed resolved the issue of specialized vocabulary in my scenario.

The following is the community discussion on this issue:
https://github.com/openai/whisper/discussions/1477
https://discuss.huggingface.co/t/adding-custom-vocabularies-on-whisper/29311
https://stackoverflow.com/questions/73833916/how-can-i-give-some-hint-phrases-to-openais-whisper-asr

Since my project utilizes faster-whisper, I will first submit it to the git project. If the submission is approved, I will synchronize it with the whisper project.