### PR TITLE
Bugfix: code breaks if audio is empty

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -388,8 +388,12 @@ class WhisperModel:
                     language = max(
                         detected_language_info,
                         key=lambda lang: len(detected_language_info[lang]),
+                        default='en',
                     )
-                    language_probability = max(detected_language_info[language])
+                    if detected_language_info:
+                        language_probability = max(detected_language_info[language])
+                    else:
+                        language_probability = 0
 
                 self.logger.info(
                     "Detected language '%s' with probability %.2f",

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -406,7 +406,7 @@ class WhisperModel:
                     "The current model is English-only but the language parameter is set to '%s'; "
                     "using 'en' instead." % language
                 )
-                language = "en"
+                language = 'en'
 
             language_probability = 1
 

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -356,7 +356,7 @@ class WhisperModel:
                     features.shape[-1] - self.feature_extractor.nb_max_frames
                 )
                 while (
-                    seek < content_frames
+                    seek <= content_frames
                     and seek
                     < self.feature_extractor.nb_max_frames * language_detection_segments
                 ):
@@ -388,12 +388,8 @@ class WhisperModel:
                     language = max(
                         detected_language_info,
                         key=lambda lang: len(detected_language_info[lang]),
-                        default="en",
                     )
-                    if detected_language_info:
-                        language_probability = max(detected_language_info[language])
-                    else:
-                        language_probability = 0
+                    language_probability = max(detected_language_info[language])
 
                 self.logger.info(
                     "Detected language '%s' with probability %.2f",

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -388,7 +388,7 @@ class WhisperModel:
                     language = max(
                         detected_language_info,
                         key=lambda lang: len(detected_language_info[lang]),
-                        default='en',
+                        default="en",
                     )
                     if detected_language_info:
                         language_probability = max(detected_language_info[language])
@@ -406,7 +406,7 @@ class WhisperModel:
                     "The current model is English-only but the language parameter is set to '%s'; "
                     "using 'en' instead." % language
                 )
-                language = 'en'
+                language = "en"
 
             language_probability = 1
 


### PR DESCRIPTION
Regression since https://github.com/SYSTRAN/faster-whisper/pull/732 PR [Improve language detection]

Bug can happen if VAD didn't found voice in audio.
Bugfix brings back the previous behaviour on empty audio.