### PR TITLE
CUDA version and updated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ GPU execution requires the following NVIDIA libraries to be installed:
 * [cuBLAS for CUDA 12](https://developer.nvidia.com/cublas)
 * [cuDNN 8 for CUDA 12](https://developer.nvidia.com/cudnn)
 
-**Note**: Latest versions of `ctranslate2` support CUDA 12 only. For CUDA 11, the current workaround is downgrading to the `3.24.0` version of `ctranslate2` (This can be done with `pip install --force-reinsall ctranslate2==3.24.0` or specifying the version in a `requirements.txt`). For more information, see: https://github.com/SYSTRAN/faster-whisper/pull/694, https://github.com/SYSTRAN/faster-whisper/issues/783, https://github.com/SYSTRAN/faster-whisper/issues/717#issuecomment-1963488371
+**Note**: Latest versions of `ctranslate2` support CUDA 12 only. For CUDA 11, the current workaround is downgrading to the `3.24.0` version of `ctranslate2` (This can be done with `pip install --force-reinsall ctranslate2==3.24.0` or specifying the version in a `requirements.txt`).
 
 There are multiple ways to install the NVIDIA libraries mentioned above. The recommended way is described in the official NVIDIA documentation, but we also suggest other installation methods below. 
 
@@ -102,7 +102,7 @@ pip install nvidia-cublas-cu12 nvidia-cudnn-cu12
 export LD_LIBRARY_PATH=`python3 -c 'import os; import nvidia.cublas.lib; import nvidia.cudnn.lib; print(os.path.dirname(nvidia.cublas.lib.__file__) + ":" + os.path.dirname(nvidia.cudnn.lib.__file__))'`
 ```
 
-**Note**: Version 9+ of `nvidia-cudnn-cu12` appears to cause issues due to the bump up to cuDNN v9. See more information on Python package versions here: https://github.com/SYSTRAN/faster-whisper/pull/785#issuecomment-2046302167
+**Note**: Version 9+ of `nvidia-cudnn-cu12` appears to cause issues due its reliance on cuDNN 9 (Faster-Whisper does not currently support cuDNN 9). Ensure your version of the Python package is for cuDNN 8.
 
 #### Download the libraries from Purfview's repository (Windows & Linux)
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ GPU execution requires the following NVIDIA libraries to be installed:
 * [cuBLAS for CUDA 12](https://developer.nvidia.com/cublas)
 * [cuDNN 8 for CUDA 12](https://developer.nvidia.com/cudnn)
 
-**Note**: Latest versions of `ctranslate2` support CUDA 12 only. For CUDA 11 support, the current workaround is using a previous version of `faster-whisper` (which depends on a previous version of `ctranslate2`). For more information, see: https://github.com/SYSTRAN/faster-whisper/pull/694, https://github.com/SYSTRAN/faster-whisper/issues/783, https://github.com/SYSTRAN/faster-whisper/issues/717#issuecomment-1963488371
+**Note**: Latest versions of `ctranslate2` support CUDA 12 only. For CUDA 11, the current workaround is downgrading to the `3.24.0` version of `ctranslate2` (This can be done with `pip install --force-reinsall ctranslate2==3.24.0` or specifying the version in a `requirements.txt`). For more information, see: https://github.com/SYSTRAN/faster-whisper/pull/694, https://github.com/SYSTRAN/faster-whisper/issues/783, https://github.com/SYSTRAN/faster-whisper/issues/717#issuecomment-1963488371
 
-There are multiple ways to install these libraries. The recommended way is described in the official NVIDIA documentation, but we also suggest other installation methods below. 
+There are multiple ways to install the NVIDIA libraries mentioned above. The recommended way is described in the official NVIDIA documentation, but we also suggest other installation methods below. 
 
 <details>
 <summary>Other installation methods (click to expand)</summary>
@@ -101,6 +101,8 @@ pip install nvidia-cublas-cu12 nvidia-cudnn-cu12
 
 export LD_LIBRARY_PATH=`python3 -c 'import os; import nvidia.cublas.lib; import nvidia.cudnn.lib; print(os.path.dirname(nvidia.cublas.lib.__file__) + ":" + os.path.dirname(nvidia.cudnn.lib.__file__))'`
 ```
+
+**Note**: Version 9+ of `nvidia-cudnn-cu12` appears to cause issues due to the bump up to cuDNN v9. See more information on Python package versions here: https://github.com/SYSTRAN/faster-whisper/pull/785#issuecomment-2046302167
 
 #### Download the libraries from Purfview's repository (Windows & Linux)
 

--- a/README.md
+++ b/README.md
@@ -75,24 +75,29 @@ Unlike openai-whisper, FFmpeg does **not** need to be installed on the system. T
 
 GPU execution requires the following NVIDIA libraries to be installed:
 
-* [cuBLAS for CUDA 11](https://developer.nvidia.com/cublas)
-* [cuDNN 8 for CUDA 11](https://developer.nvidia.com/cudnn)
+* [cuBLAS for CUDA 12](https://developer.nvidia.com/cublas)
+* [cuDNN 8 for CUDA 12](https://developer.nvidia.com/cudnn)
 
-There are multiple ways to install these libraries. The recommended way is described in the official NVIDIA documentation, but we also suggest other installation methods below.
+**Note**: Latest versions of `ctranslate2` support CUDA 12 only. For CUDA 11 support, the current workaround is using a previous version of `faster-whisper` (which depends on a previous version of `ctranslate2`). For more information, see: https://github.com/SYSTRAN/faster-whisper/pull/694, https://github.com/SYSTRAN/faster-whisper/issues/783, https://github.com/SYSTRAN/faster-whisper/issues/717#issuecomment-1963488371
+
+There are multiple ways to install these libraries. The recommended way is described in the official NVIDIA documentation, but we also suggest other installation methods below. 
 
 <details>
 <summary>Other installation methods (click to expand)</summary>
 
+
+**Note:** For all these methods below, keep in mind the above note regarding CUDA versions. Depending on your setup, you may need to install the _CUDA 11_ versions of libraries that correspond to the CUDA 12 libraries listed in the instructions below.
+
 #### Use Docker
 
-The libraries are installed in this official NVIDIA Docker image: `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04`.
+The libraries (cuBLAS, cuDNN) are installed in these official NVIDIA CUDA Docker images: `nvidia/cuda:12.0.0-runtime-ubuntu20.04` or `nvidia/cuda:12.0.0-runtime-ubuntu22.04`.
 
 #### Install with `pip` (Linux only)
 
 On Linux these libraries can be installed with `pip`. Note that `LD_LIBRARY_PATH` must be set before launching Python.
 
 ```bash
-pip install nvidia-cublas-cu11 nvidia-cudnn-cu11
+pip install nvidia-cublas-cu12 nvidia-cudnn-cu12
 
 export LD_LIBRARY_PATH=`python3 -c 'import os; import nvidia.cublas.lib; import nvidia.cudnn.lib; print(os.path.dirname(nvidia.cublas.lib.__file__) + ":" + os.path.dirname(nvidia.cudnn.lib.__file__))'`
 ```


### PR DESCRIPTION
Edits to the README regarding installation/CUDA based on discussion on these issues: https://github.com/SYSTRAN/faster-whisper/issues/783 and https://github.com/SYSTRAN/faster-whisper/issues/717

- Updated libraries to install for CUDA 12 (because of latest `ctranslate2` support for only CUDA 12)
- Added note regarding CUDA 11 support.