### PR TITLE
Loosen tokenizers version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 av==11.*
 ctranslate2>=4.0,<5
 huggingface_hub>=0.13
-tokenizers>=0.13,<0.16
+tokenizers>=0.13,<1
 onnxruntime>=1.14,<2


### PR DESCRIPTION
Constraining the version of tokenizers to `<0.16` makes faster-whisper incompatible with the latest version of transformers, and the tests all pass when using the latest version (`0.19.1`).