### PR TITLE
Fix #839 incorrect clip_timestamps being used in model

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -490,14 +490,16 @@ class WhisperModel:
         content_duration = float(content_frames * self.feature_extractor.time_per_frame)
 
         if isinstance(options.clip_timestamps, str):
-            options = options._replace(clip_timestamps=[
-                float(ts)
-                for ts in (
-                    options.clip_timestamps.split(",")
-                    if options.clip_timestamps
-                    else []
-                )
-            ])
+            options = options._replace(
+                clip_timestamps=[
+                    float(ts)
+                    for ts in (
+                        options.clip_timestamps.split(",")
+                        if options.clip_timestamps
+                        else []
+                    )
+                ]
+            )
         seek_points: List[int] = [
             round(ts * self.frames_per_second) for ts in options.clip_timestamps
         ]

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -490,14 +490,14 @@ class WhisperModel:
         content_duration = float(content_frames * self.feature_extractor.time_per_frame)
 
         if isinstance(options.clip_timestamps, str):
-            TranscriptionOptions.clip_timestamps = [
+            options = options._replace(clip_timestamps=[
                 float(ts)
                 for ts in (
                     options.clip_timestamps.split(",")
                     if options.clip_timestamps
                     else []
                 )
-            ]
+            ])
         seek_points: List[int] = [
             round(ts * self.frames_per_second) for ts in options.clip_timestamps
         ]


### PR DESCRIPTION
Changed the code from updating the TranscriptionOptions class instead of the options object (transcribe.py, lines 493-500), which likely was the cause of the unexpected behaviour of clip_timestamps not updating when calling transcribe multiple times

Original:
```py
TranscriptionOptions.clip_timestamps=[
    float(ts)
    for ts in (
        options.clip_timestamps.split(",")
        if options.clip_timestamps
        else []
    )
]
```

Updated:
```py
options = options._replace(
  clip_timestamps=[
      float(ts)
      for ts in (
          options.clip_timestamps.split(",")
          if options.clip_timestamps
          else []
      )
  ]
)
```