### PR TITLE
fix: grouping audio frames causes memory problems and is maybe slightly slower?

### DIFF
--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -46,7 +46,6 @@ def decode_audio(
     with av.open(input_file, mode="r", metadata_errors="ignore") as container:
         frames = container.decode(audio=0)
         frames = _ignore_invalid_frames(frames)
-        frames = _group_frames(frames, 500000)
         frames = _resample_frames(frames, resampler)
 
         for frame in frames:
@@ -82,21 +81,6 @@ def _ignore_invalid_frames(frames):
             break
         except av.error.InvalidDataError:
             continue
-
-
-def _group_frames(frames, num_samples=None):
-    fifo = av.audio.fifo.AudioFifo()
-
-    for frame in frames:
-        frame.pts = None  # Ignore timestamp check.
-        fifo.write(frame)
-
-        if num_samples is not None and fifo.samples >= num_samples:
-            yield fifo.read()
-
-    if fifo.samples > 0:
-        yield fifo.read()
-
 
 def _resample_frames(frames, resampler):
     # Add None to flush the resampler.


### PR DESCRIPTION
In our testing we found that this grouping allocates around 100 bytes per audio sample even for incredibly small videos.

For example an 8 second 1.36 MB videos allocates 18.9MB (I think it should be around 33, unsure why it is only halfl)


It doesn't require much imagination to compute what would happen on really big videos.
This will trigger memory limits pretty constantly on production deployents, and single handedly makes faster-whisper unsuitable for production systems.

Before my change:
```
   125    727.3 MiB      3.5 MiB           2       with av.open(input_file, metadata_errors="ignore") as container:
   126    708.4 MiB      0.0 MiB           1           frames = container.decode(audio=0)
   127    708.4 MiB      0.0 MiB           1           frames = _ignore_invalid_frames(frames)
   128    708.4 MiB      0.0 MiB           1           frames = _group_frames(frames, 500000)
   129    708.4 MiB      0.0 MiB           1           frames = _resample_frames(frames, resampler)
   130                                         
   131    727.3 MiB     18.9 MiB           3           for frame in frames:
   132    727.3 MiB      0.0 MiB           2               array = frame.to_ndarray()
   133    727.3 MiB      0.0 MiB           2               dtype = array.dtype
   134    727.3 MiB      0.0 MiB           2               raw_buffer.write(array)
   135                                         
   136                                             # It appears that some objects related to the resampler are not freed
   137                                             # unless the garbage collector is manually run.
   138    727.3 MiB      0.0 MiB           1       del resampler
   139    721.8 MiB     -5.5 MiB           1       gc.collect()
```


After my change:
```
   129    709.4 MiB      0.0 MiB           1           frames = _resample_frames(frames, resampler)
   130                                         
   131    710.6 MiB      0.8 MiB         182           for frame in frames:
   132    710.6 MiB      0.0 MiB         181               array = frame.to_ndarray()
   133    710.6 MiB      0.0 MiB         181               dtype = array.dtype
   134    710.6 MiB      0.4 MiB         181               raw_buffer.write(array)
   135                                         
   136                                             # It appears that some objects related to the resampler are not freed
   137                                             # unless the garbage collector is manually run.
   138    710.6 MiB      0.0 MiB           1       del resampler
   139    710.6 MiB      0.0 MiB           1       gc.collect()
```


The performance difference is this on a few hundred requests:
```
without group
max 0.940046314150095
average 0.7971834561880677
min 0.7308510262519121

with group
max 0.9293739395216107
average 0.8034254801739007
min 0.7338719926774502

```

I won't die on the performance hill.