### PR TITLE
Add distil models to WhisperModel init and download_model docstrings

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -100,7 +100,8 @@ class WhisperModel:
 
         Args:
           model_size_or_path: Size of the model to use (tiny, tiny.en, base, base.en,
-            small, small.en, medium, medium.en, large-v1, large-v2, large-v3, or large), a path to a
+            small, small.en, distil-small.en, medium, medium.en, distil-medium.en, large-v1, 
+            large-v2, large-v3, large, distil-large-v2 or distil-large-v3), a path to a
             converted model directory, or a CTranslate2-converted Whisper model ID from the HF Hub.
             When a size or a model ID is configured, the converted model is downloaded
             from the Hugging Face Hub.

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -100,7 +100,7 @@ class WhisperModel:
 
         Args:
           model_size_or_path: Size of the model to use (tiny, tiny.en, base, base.en,
-            small, small.en, distil-small.en, medium, medium.en, distil-medium.en, large-v1, 
+            small, small.en, distil-small.en, medium, medium.en, distil-medium.en, large-v1,
             large-v2, large-v3, large, distil-large-v2 or distil-large-v3), a path to a
             converted model directory, or a CTranslate2-converted Whisper model ID from the HF Hub.
             When a size or a model ID is configured, the converted model is downloaded

--- a/faster_whisper/utils.py
+++ b/faster_whisper/utils.py
@@ -54,8 +54,9 @@ def download_model(
 
     Args:
       size_or_id: Size of the model to download from https://huggingface.co/Systran
-        (tiny, tiny.en, base, base.en, small, small.en medium, medium.en, large-v1, large-v2,
-        large-v3, large), or a CTranslate2-converted model ID from the Hugging Face Hub
+        (tiny, tiny.en, base, base.en, small, small.en, distil-small.en, medium, medium.en, 
+        distil-medium.en, large-v1, large-v2, large-v3, large, distil-large-v2, 
+        distil-large-v3), or a CTranslate2-converted model ID from the Hugging Face Hub
         (e.g. Systran/faster-whisper-large-v3).
       output_dir: Directory where the model should be saved. If not set, the model is saved in
         the cache directory.

--- a/faster_whisper/utils.py
+++ b/faster_whisper/utils.py
@@ -54,8 +54,8 @@ def download_model(
 
     Args:
       size_or_id: Size of the model to download from https://huggingface.co/Systran
-        (tiny, tiny.en, base, base.en, small, small.en, distil-small.en, medium, medium.en, 
-        distil-medium.en, large-v1, large-v2, large-v3, large, distil-large-v2, 
+        (tiny, tiny.en, base, base.en, small, small.en, distil-small.en, medium, medium.en,
+        distil-medium.en, large-v1, large-v2, large-v3, large, distil-large-v2,
         distil-large-v3), or a CTranslate2-converted model ID from the Hugging Face Hub
         (e.g. Systran/faster-whisper-large-v3).
       output_dir: Directory where the model should be saved. If not set, the model is saved in


### PR DESCRIPTION
This PR updates the `WhisperModel` `__init__` method and the `download_model` docstrings to include the new distil variants. This enhancement allows code editors to display the available models in their hints