### PR TITLE
Docker file improvements

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,6 @@
-FROM nvidia/cuda:12.0.0-runtime-ubuntu20.04
-
+FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
 WORKDIR /root
-RUN apt-get update -y && apt-get install -y python3 python3-pip libcudnn8 libcudnn8-dev
+RUN apt-get update -y && apt-get install -y python3-pip
 COPY infer.py jfk.flac ./
 RUN pip3 install faster-whisper
-
-ENTRYPOINT ["python3", "infer.py"]
+CMD ["python3", "infer.py"]


### PR DESCRIPTION
Installation of `libcudnn8` and `libcudnn8-dev` isn't necessary when using `nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04` as the base image

Build time reduced from 165s to 53s (on g6.4xlarge EC2 instance) 
Final image size reduced from 6.07GB to 4.6GB