### PR TITLE
docs: add 'faster-whisper-server' community integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ See more model and transcription options in the [`WhisperModel`](https://github.
 Here is a non exhaustive list of open-source projects using faster-whisper. Feel free to add your project to the list!
 
 
+* [faster-whisper-server](https://github.com/fedirz/faster-whisper-server) is an OpenAI compatible server using `faster-whisper`. It's easily deployable with Docker, works with OpenAI SDKs/CLI, supports streaming, and live transcription.
 * [WhisperX](https://github.com/m-bain/whisperX) is an award-winning Python library that offers speaker diarization and accurate word-level timestamps using wav2vec2 alignment
 * [whisper-ctranslate2](https://github.com/Softcatala/whisper-ctranslate2) is a command line client based on faster-whisper and compatible with the original client from openai/whisper.
 * [whisper-diarize](https://github.com/MahmoudAshraf97/whisper-diarization) is a speaker diarization tool that is based on faster-whisper and NVIDIA NeMo.


### PR DESCRIPTION
Hey, I've just created a [faster-whisper-server](https://github.com/fedirz/faster-whisper-server), and I'd like to add it to the list of community integrations. I think it could be useful to some folks that want to work with `faster-whisper` using other programming languages or using an OpenAI SDKs.