### PR TITLE
Remove the usage of `transformers.pipeline` from `BatchedInferencePipeline` and fix word timestamps for batched inference

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -522,9 +522,9 @@ class BatchedInferencePipeline:
         )
         features = torch.stack(
             [
-                self.model.feature_extractor(
-                    audio_segment, chunk_length=self.chunk_length, to_cpu=to_cpu
-                )[..., : self.model.feature_extractor.nb_max_frames]
+                self.model.feature_extractor(audio_segment, to_cpu=to_cpu)[
+                    ..., : self.model.feature_extractor.nb_max_frames
+                ]
                 for audio_segment in audio_segments
             ]
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ctranslate2>=4.0,<5
 huggingface_hub>=0.13
 tokenizers>=0.13,<1
 onnxruntime>=1.14,<2 
-transformers
 pyannote-audio>=3.1.1
 torch>=2.1.1 
 torchaudio>=2.1.2
+tqdm


### PR DESCRIPTION
This PR removes Remove the usage of `transformers.pipeline` from `BatchedInferencePipeline` because there's no need to use it in the first place
this simplifies the code and removes a requirement
it also fixes #919 
it was caused by wrong `num_frames` argument when finding the alignments, it was assumed that inferring it from encoder output size was sufficient but turned out to cause issues such as #919 when the actual segment size is much less that the inferred size