### PR TITLE
limit pytorch version to cudnn8 for `pip install`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ huggingface_hub>=0.13
 tokenizers>=0.13,<1
 onnxruntime>=1.14,<2 
 pyannote-audio>=3.1.1
-torch>=2.1.1 
-torchaudio>=2.1.2
+torch>=2.1.1,<2.4.0
+torchaudio>=2.1.2,<2.4.0
 tqdm


### PR DESCRIPTION
> Note: Version 9+ of nvidia-cudnn-cu12 appears to cause issues due its reliance on cuDNN 9 (Faster-Whisper does not currently support cuDNN 9). Ensure your version of the Python package is for cuDNN 8.

because all pytorch>=2.4 on conda are started to be compiled with cudnn9, 
so this PR can avoid new users who just installed with `pip install faster-whisper` from getting into the issue:
```
>>Performing transcription...
Could not locate cudnn_ops_infer64_8.dll. Please make sure it is in your library path!
```
 just after installing.