### PR TITLE
Return empty generator when no active speech in transcribe

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -513,9 +513,11 @@ class BatchedInferencePipeline:
 
         # Handle for when there is no active speech
         if len(vad_segments) == 0:
+
             def empty_gen():
                 return
                 yield
+
             return empty_gen(), info
 
         audio_segments, segments_metadata = self.audio_split(


### PR DESCRIPTION
To fix
`/lib/python3.10/site-packages/faster_whisper/transcribe.py", line 523, in transcribe features = torch.stack( RuntimeError: stack expects a non-empty TensorList`

when there is no active speech, i.e. `vad_segments` after `merge_chunks` is empty.