### PR TITLE
fix:The timestamps for the second and subsequent segments are incorrect

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -2085,9 +2085,11 @@ def restore_speech_timestamps(
             )
 
         else:
+            middle = (segment.start + segment.end) / 2
+            chunk_index = ts_map.get_chunk_index(middle)
             segment = segment._replace(
-                start=ts_map.get_original_time(segment.start),
-                end=ts_map.get_original_time(segment.end),
+                start=ts_map.get_original_time(segment.start, chunk_index),
+                end=ts_map.get_original_time(segment.end, chunk_index),
             )
 
         yield segment


### PR DESCRIPTION
When VAD detects multiple segments of speech in an audio clip, the timestamps from the second segment onward are incorrect, as shown in the image below
This is incorrect：
![image](https://github.com/user-attachments/assets/1149e894-c4f1-4d0c-95c6-78b959cf3710)
This is correct：
![image](https://github.com/user-attachments/assets/23cd0c46-a235-470a-b252-b274079321f8)

