### PR TITLE
fix a typo in detect_language_multi_segment comment

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -1860,7 +1860,7 @@ class WhisperModel:
         Detect language based on N highly-confident segments of a language.
         """
         # The threshold is used to decide if the audio is silence or not.
-        # The default is 0.02 (2.0%) i.e, if more than 2.0% of the audio is silent,
+        # The default is 0.02 (2.0%) i.e, if more than 98.0% of the audio is silent,
         # the audio is considered as silence.
         if not params:
             params = {


### PR DESCRIPTION
Hello,

There is a typo in a parameter explanation. This definition is incorrect:

https://github.com/SYSTRAN/faster-whisper/blob/d57c5b40b06e59ec44240d93485a95799548af50/faster_whisper/transcribe.py#L1863

 This definition is the correct one: https://github.com/SYSTRAN/faster-whisper/blob/d57c5b40b06e59ec44240d93485a95799548af50/faster_whisper/transcribe.py#L1917

I updated the incorrect comment to reflect the correct meaning.

cc: @MahmoudAshraf97 