### PR TITLE
New PR: Allow users to add their own customised model without editing existing faster-whisper code

### DIFF
--- a/faster_whisper/utils.py
+++ b/faster_whisper/utils.py
@@ -29,6 +29,12 @@ _MODELS = {
 }
 
 
+def add_model(model_dict) -> dict:
+    """Adds a dictionary of custom Models to existing Model"""
+    _MODELS.update(model_dict)
+    return _MODELS
+
+
 def available_models() -> List[str]:
     """Returns the names of available models."""
     return list(_MODELS.keys())


### PR DESCRIPTION
Added a user-friendly function to allow users to add their own Hugging Face ct2 models. This allows others to directly use any updated faster-whisper models without having to wait for others to update existing faster-whisper. 