### PR TITLE
Update requirements.txt: latest release from ctranslate2 from 10-22-2024 breaks faster-whisper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ctranslate2>=4.0,<5
+ctranslate2>=4.0,<=4.4.0
 huggingface_hub>=0.13
 tokenizers>=0.13,<1
 onnxruntime>=1.14,<2 


### PR DESCRIPTION
latest release from ctranslate2 from 10-22-2024 breaks faster-whisper. See release history here: https://pypi.org/project/ctranslate2/4.4.0/#history

I have edited the requirements.txt file to remedy this and limited the range from 4.0, 4.4.0 which is the latest working version for ctranslate2 with faster-whisper instead of 4.0, 5

