### PR TITLE
Pad audio instead of mel features to reduce word error rates

### DIFF
--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -107,26 +107,3 @@ def _resample_frames(frames, resampler):
     # Add None to flush the resampler.
     for frame in itertools.chain(frames, [None]):
         yield from resampler.resample(frame)
-
-
-def pad_or_trim(array, length: int, *, axis: int = -1):
-    """
-    Pad or trim the audio array to N_SAMPLES, as expected by the encoder.
-    """
-    axis = axis % array.ndim
-    if array.shape[axis] > length:
-        idx = [Ellipsis] * axis + [slice(length)] + [Ellipsis] * (array.ndim - axis - 1)
-        return array[idx]
-
-    if array.shape[axis] < length:
-        pad_widths = (
-            [
-                0,
-            ]
-            * array.ndim
-            * 2
-        )
-        pad_widths[2 * axis] = length - array.shape[axis]
-        array = torch.nn.functional.pad(array, tuple(pad_widths[::-1]))
-
-    return array

--- a/faster_whisper/feature_extractor.py
+++ b/faster_whisper/feature_extractor.py
@@ -20,7 +20,7 @@ class FeatureExtractor:
         self.hop_length = hop_length
         self.chunk_length = chunk_length
         self.n_samples = chunk_length * sampling_rate
-        self.nb_max_frames = self.n_samples // hop_length
+        self.nb_max_frames = (30 * sampling_rate) // hop_length
         self.time_per_frame = hop_length / sampling_rate
         self.sampling_rate = sampling_rate
         self.mel_filters = self.get_mel_filters(
@@ -82,7 +82,6 @@ class FeatureExtractor:
 
         if chunk_length is not None:
             self.n_samples = chunk_length * self.sampling_rate
-            self.nb_max_frames = self.n_samples // self.hop_length
 
         if waveform.dtype is not torch.float32:
             waveform = waveform.to(torch.float32)


### PR DESCRIPTION
This PR pads audio before feature extraction instead of padding the features, this is inline with how the whisper model was trained because reverting the zero-padded Mel spectrogram features back to time domain results in a white noise with moderate amplitude that causes hallucinations and wrong transcriptions
The `distil-large-v3` WER dropped from 26.04 at 83a368e98a7b49621029f3067711fa895a97083f to 14.472 
This figure can be reproduced by running `benchmarks/yt_commons.py` and switching the batched inference to sequential

These are WER comparisons before and after
```python
word_timestamps=False,
without_timestamps=True,
vad_filter=True,
```

| Model               | Before WER | After WER  |
|---------------------|------------|------------|
| tiny.en             | **17.936** | 18.701     |
| tiny                | **20.056** | 21.085     |
| base.en             | **18.002** | 19.286     |
| base                | **18.366** | 18.921     |
| small.en            | 20.743     | **19.557** |
| small               | **18.853** | 19.177     |
| medium.en           | 21.755     | **20.323** |
| medium              | **21.833** | 21.979     |
| large-v1            | 22.319     | **21.195** |
| large-v2            | 17.083     | **16.960** |
| large-v3            | 20.946     | **19.961** |
| distil-large-v2     | **71.848** | 85.386     |
| distil-medium.en    | **68.044** | 68.556     |
| distil-small.en     | 68.719     | **67.453** |
| distil-large-v3     | 26.277     | **14.520** |
| large-v3-turbo      | 23.999     | **22.679** |


References:
https://github.com/openai/whisper/discussions/730#discussion-4678866
https://github.com/openai/whisper/discussions/838#discussioncomment-5222689