### PR TITLE
Audio

### DIFF
--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -54,7 +54,7 @@ def decode_audio(
             array = frame.to_ndarray()
             dtype = array.dtype
             raw_buffer.write(array.tobytes())
-    
+
     # It appears that some objects related to the resampler are not freed
     # unless the garbage collector is manually run.
     # https://github.com/SYSTRAN/faster-whisper/issues/390

--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -53,8 +53,8 @@ def decode_audio(
         for frame in frames:
             array = frame.to_ndarray()
             dtype = array.dtype
-            raw_buffer.write(array)
-
+            raw_buffer.write(array.tobytes())
+    
     # It appears that some objects related to the resampler are not freed
     # unless the garbage collector is manually run.
     # https://github.com/SYSTRAN/faster-whisper/issues/390


### PR DESCRIPTION
Change the decode_audio function to write the bytes representation of the NumPy array using array.tobytes() when writing to the raw_buffer.  This explicitly handles the data conversion to bytes, which enhances code clarity, ensures compatibility across different Python versions and environments, avoids potential issues with the buffer protocol, and improves the robustness and portability of the code without altering its functionality working with the rest of the program.