### PR TITLE
Use correct features padding for encoder input

### DIFF
--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -109,9 +109,9 @@ def _resample_frames(frames, resampler):
         yield from resampler.resample(frame)
 
 
-def pad_or_trim(array, length: int, *, axis: int = -1):
+def pad_or_trim(array, length: int = 3000, *, axis: int = -1):
     """
-    Pad or trim the audio array to N_SAMPLES, as expected by the encoder.
+    Pad or trim the Mel features array to 3000, as expected by the encoder.
     """
     axis = axis % array.ndim
     if array.shape[axis] > length:

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -443,7 +443,8 @@ class BatchedInferencePipeline:
                 [
                     pad_or_trim(
                         self.model.feature_extractor(chunk, to_cpu=to_cpu)[
-                            ..., : self.model.feature_extractor.nb_max_frames
+                            ...,
+                            : chunk.shape[0] // self.model.feature_extractor.hop_length,
                         ]
                     )
                     for chunk in audio_chunks


### PR DESCRIPTION
This adheres faster whisper implementation to the original OpenAI implementation as discussed in #1084 

These are WER comparisons before and after
These figures can be reproduced by running `benchmarks/yt_commons.py` and switching the batched inference to sequential
```python
word_timestamps=False,
without_timestamps=True,
vad_filter=True,
```

| Model               | Before WER | After WER  |
|---------------------|------------|------------|
| distil-large-v3     | 26.277     | **14.762** |
| distil-large-v2     | **71.848** | 81.456    |
| distil-medium.en    | 68.044 | **66.565**     |
| distil-small.en     | 68.719     | **67.220** |

the performance regression of `distil-large-v2` can be ignored because `distil-large-v3` should be used as a drop-in replacement

This should also affect all use cases where chunk length is less than 30 for all models
There is also an average WER improvement by around 2% (relative) for batched inference across all models

| Model               | Before WER | After WER  |
|---------------------|------------|------------|
| tiny.en             | 15.437 | 15.063     |
| tiny                | 21.765 | 21.390     |
| base.en             | 14.300 | 13.816     |
| base                | 17.709 | 17.251     |
| small.en            | 13.054     | 12.617 |
| small               | 16.413 | 16.088    |
| medium.en           | 13.299     | 12.894 |
| medium              | 15.991 | 15.593     |
| large-v1            | 19.458     | 19.590 |
| large-v2            | 15.237     | 15.148 |
| large-v3            | 16.514     | 15.997 |
| large-v3-turbo      | 14.576     | 14.044 |
| distil-small.en     | 14.004     | 13.918 |
| distil-medium.en    | 14.074 | 13.972     |
| distil-large-v2     | 13.419 | 13.574     |
| distil-large-v3     | 13.688     | 13.533 |
