### PR TITLE
replace `NamedTuple` with `dataclass`

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -10,6 +10,7 @@ from dataclasses import asdict, dataclass
 from inspect import signature
 from math import ceil
 from typing import BinaryIO, Iterable, List, Optional, Tuple, Union
+from warnings import warn
 
 import ctranslate2
 import numpy as np
@@ -39,6 +40,11 @@ class Word:
     probability: float
 
     def _asdict(self):
+        warn(
+            "Word._asdict() method is deprecated, use dataclasses.asdict(Word) instead",
+            DeprecationWarning,
+            2,
+        )
         return asdict(self)
 
 
@@ -57,6 +63,11 @@ class Segment:
     temperature: Optional[float] = 1.0
 
     def _asdict(self):
+        warn(
+            "Segment._asdict() method is deprecated, use dataclasses.asdict(Segment) instead",
+            DeprecationWarning,
+            2,
+        )
         return asdict(self)
 
 

--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -2,7 +2,8 @@ import bisect
 import functools
 import os
 
-from typing import Dict, List, NamedTuple, Optional, Tuple
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -11,7 +12,8 @@ from faster_whisper.utils import get_assets_path
 
 
 # The code below is adapted from https://github.com/snakers4/silero-vad.
-class VadOptions(NamedTuple):
+@dataclass
+class VadOptions:
     """VAD options.
 
     Attributes:


### PR DESCRIPTION
this is to allow conversion of `Segment` and `Words` to `dict` or `json` without recursively going through them
Similar to #667 and #1104 

Unlike NamedTuples, dataclasses are not iterable, so they need to be converted to a dict first