### PR TITLE
Remove `torch` dependency, Faster numpy Feature extraction

### DIFF
--- a/faster_whisper/feature_extractor.py
+++ b/faster_whisper/feature_extractor.py
@@ -1,7 +1,20 @@
-import torch
+import numpy as np
+
+try:
+    import cupy as cp
+
+    CUPY_AVAILABLE = True
+except ImportError:
+    CUPY_AVAILABLE = False
 
 
-# Adapted from https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/feature_extraction_whisper.py  # noqa: E501
+def get_array_module(device: str = "auto"):
+    if device in ["auto", "cuda"] and CUPY_AVAILABLE and cp.cuda.is_available():
+        return cp, "cuda"
+    else:
+        return np, "cpu"
+
+
 class FeatureExtractor:
     def __init__(
         self,
@@ -12,10 +25,8 @@ class FeatureExtractor:
         chunk_length=30,
         n_fft=400,
     ):
-        if device == "auto":
-            self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        else:
-            self.device = device
+        self.array_module: np
+        self.array_module, self._device = get_array_module(device)
         self.n_fft = n_fft
         self.hop_length = hop_length
         self.chunk_length = chunk_length
@@ -25,24 +36,20 @@ class FeatureExtractor:
         self.sampling_rate = sampling_rate
         self.mel_filters = self.get_mel_filters(
             sampling_rate, n_fft, n_mels=feature_size
-        )
+        ).astype("float32")
 
-    @staticmethod
-    def get_mel_filters(sr, n_fft, n_mels=128):
-        """
-        Implementation of librosa.filters.mel in Pytorch
-        """
+    def get_mel_filters(self, sr, n_fft, n_mels=128):
         # Initialize the weights
         n_mels = int(n_mels)
 
         # Center freqs of each FFT bin
-        fftfreqs = torch.fft.rfftfreq(n=n_fft, d=1.0 / sr)
+        fftfreqs = self.array_module.fft.rfftfreq(n=n_fft, d=1.0 / sr)
 
         # 'Center freqs' of mel bands - uniformly spaced between limits
         min_mel = 0.0
         max_mel = 45.245640471924965
 
-        mels = torch.linspace(min_mel, max_mel, n_mels + 2)
+        mels = self.array_module.linspace(min_mel, max_mel, n_mels + 2)
 
         # Fill in the linear scale
         f_min = 0.0
@@ -52,30 +59,32 @@ class FeatureExtractor:
         # And now the nonlinear scale
         min_log_hz = 1000.0  # beginning of log region (Hz)
         min_log_mel = (min_log_hz - f_min) / f_sp  # same (Mels)
-        logstep = torch.log(torch.tensor(6.4)) / 27.0  # step size for log region
+        logstep = self.array_module.log(6.4) / 27.0  # step size for log region
 
         # If we have vector data, vectorize
         log_t = mels >= min_log_mel
-        freqs[log_t] = min_log_hz * torch.exp(logstep * (mels[log_t] - min_log_mel))
+        freqs[log_t] = min_log_hz * self.array_module.exp(
+            logstep * (mels[log_t] - min_log_mel)
+        )
 
-        mel_f = freqs
+        fdiff = self.array_module.diff(freqs)
+        ramps = freqs.reshape(-1, 1) - fftfreqs.reshape(1, -1)
 
-        fdiff = torch.diff(mel_f)
-        ramps = mel_f.view(-1, 1) - fftfreqs.view(1, -1)
-
-        lower = -ramps[:-2] / fdiff[:-1].unsqueeze(1)
-        upper = ramps[2:] / fdiff[1:].unsqueeze(1)
+        lower = -ramps[:-2] / self.array_module.expand_dims(fdiff[:-1], axis=1)
+        upper = ramps[2:] / self.array_module.expand_dims(fdiff[1:], axis=1)
 
         # Intersect them with each other and zero, vectorized across all i
-        weights = torch.maximum(torch.zeros_like(lower), torch.minimum(lower, upper))
+        weights = self.array_module.maximum(
+            self.array_module.zeros_like(lower), self.array_module.minimum(lower, upper)
+        )
 
         # Slaney-style mel is scaled to be approx constant energy per channel
-        enorm = 2.0 / (mel_f[2 : n_mels + 2] - mel_f[:n_mels])
-        weights *= enorm.unsqueeze(1)
+        enorm = 2.0 / (freqs[2 : n_mels + 2] - freqs[:n_mels])
+        weights *= self.array_module.expand_dims(enorm, axis=1)
 
         return weights
 
-    def __call__(self, waveform, padding=True, chunk_length=None, to_cpu=False):
+    def __call__(self, waveform: np.ndarray, padding=True, chunk_length=None):
         """
         Compute the log-Mel spectrogram of the provided audio.
         """
@@ -84,31 +93,167 @@ class FeatureExtractor:
             self.n_samples = chunk_length * self.sampling_rate
             self.nb_max_frames = self.n_samples // self.hop_length
 
-        if waveform.dtype is not torch.float32:
-            waveform = waveform.to(torch.float32)
-
-        waveform = (
-            waveform.to(self.device)
-            if self.device == "cuda" and not waveform.is_cuda
-            else waveform
-        )
+        if waveform.dtype is not np.float32:
+            waveform = waveform.astype(np.float32)
 
         if padding:
-            waveform = torch.nn.functional.pad(waveform, (0, self.n_samples))
+            waveform = np.pad(waveform, (0, self.n_samples))
 
-        window = torch.hann_window(self.n_fft).to(waveform.device)
+        window = self.array_module.hanning(self.n_fft + 1)[:-1].astype("float32")
 
-        stft = torch.stft(
-            waveform, self.n_fft, self.hop_length, window=window, return_complex=True
+        stft_output = stft(
+            self.array_module,
+            waveform,
+            self.n_fft,
+            self.hop_length,
+            window=window,
+            return_complex=True,
         )
-        magnitudes = stft[..., :-1].abs() ** 2
+        magnitudes = self.array_module.abs(stft_output[..., :-1]) ** 2
 
-        mel_spec = self.mel_filters.to(waveform.device) @ magnitudes
+        mel_spec = self.mel_filters @ magnitudes
 
-        log_spec = torch.clamp(mel_spec, min=1e-10).log10()
-        log_spec = torch.maximum(log_spec, log_spec.max() - 8.0)
+        log_spec = self.array_module.log10(
+            self.array_module.clip(mel_spec, a_min=1e-10, a_max=None)
+        )
+        log_spec = self.array_module.maximum(log_spec, log_spec.max() - 8.0)
         log_spec = (log_spec + 4.0) / 4.0
 
-        # When the model is running on multiple GPUs, the output should be moved
-        # to the CPU since we don't know which GPU will handle the next job.
-        return log_spec.cpu() if to_cpu else log_spec
+        return np.asarray(log_spec.tolist(), dtype=log_spec.dtype)
+
+    @property
+    def device(self):
+        return self._device
+
+    @device.setter
+    def device(self, device):
+        if device != self.device:
+            self.array_module, self._device = get_array_module(device)
+
+
+def stft(
+    array_module: np,
+    input_tensor: np.ndarray,
+    n_fft: int,
+    hop_length: int = None,
+    win_length: int = None,
+    window: np.ndarray = None,
+    center=True,
+    mode="reflect",
+    normalized=False,
+    onesided=None,
+    return_complex=None,
+):
+
+    # Default initialization for hop_length and win_length
+    hop_length = hop_length if hop_length is not None else n_fft // 4
+    win_length = win_length if win_length is not None else n_fft
+    input_is_complex = np.iscomplexobj(input_tensor)
+
+    # Determine if the output should be complex
+    return_complex = (
+        return_complex
+        if return_complex is not None
+        else (input_is_complex or (window is not None and np.iscomplexobj(window)))
+    )
+
+    if not return_complex and return_complex is None:
+        raise ValueError("stft requires the return_complex parameter for real inputs.")
+
+    # Input checks
+    if not np.issubdtype(input_tensor.dtype, np.floating) and not input_is_complex:
+        raise ValueError(
+            f"stft: expected a tensor of floating point or complex values, got {input_tensor.dtype}"
+        )
+
+    if input_tensor.ndim > 2 or input_tensor.ndim < 1:
+        raise ValueError(
+            f"stft: expected a 1D or 2D tensor, but got {input_tensor.ndim}D tensor"
+        )
+
+    # Handle 1D input
+    if input_tensor.ndim == 1:
+        input_tensor = np.expand_dims(input_tensor, axis=0)
+        input_tensor_1d = True
+    else:
+        input_tensor_1d = False
+
+    # Center padding if required
+    if center:
+        pad_amount = n_fft // 2
+        input_tensor = np.pad(
+            input_tensor, ((0, 0), (pad_amount, pad_amount)), mode=mode
+        )
+
+    batch, length = input_tensor.shape
+
+    # Additional input checks
+    if n_fft <= 0 or n_fft > length:
+        raise ValueError(f"stft: expected 0 < n_fft <= {length}, but got n_fft={n_fft}")
+
+    if hop_length <= 0:
+        raise ValueError(
+            f"stft: expected hop_length > 0, but got hop_length={hop_length}"
+        )
+
+    if win_length <= 0 or win_length > n_fft:
+        raise ValueError(
+            f"stft: expected 0 < win_length <= n_fft, but got win_length={win_length}"
+        )
+
+    if window is not None:
+        if window.ndim != 1 or window.shape[0] != win_length:
+            raise ValueError(
+                f"stft: expected a 1D window tensor of size equal to win_length={win_length}, "
+                f"but got window with size {window.shape}"
+            )
+
+    # Handle padding of the window if necessary
+    if win_length < n_fft:
+        left = (n_fft - win_length) // 2
+        window_ = array_module.zeros(n_fft, dtype=window.dtype)
+        window_[left : left + win_length] = window
+    else:
+        window_ = window
+
+    # Calculate the number of frames
+    n_frames = 1 + (length - n_fft) // hop_length
+
+    # Time to columns
+    input_tensor = np.lib.stride_tricks.as_strided(
+        input_tensor,
+        (batch, n_frames, n_fft),
+        (
+            input_tensor.strides[0],
+            hop_length * input_tensor.strides[1],
+            input_tensor.strides[1],
+        ),
+    )
+
+    if window_ is not None:
+        input_tensor = array_module.asarray(input_tensor) * window_
+
+    # FFT and transpose
+    complex_fft = input_is_complex
+    onesided = onesided if onesided is not None else not complex_fft
+
+    if normalized:
+        norm = "ortho"
+    else:
+        norm = None
+
+    if complex_fft:
+        if onesided:
+            raise ValueError(
+                "Cannot have onesided output if window or input is complex"
+            )
+        output = array_module.fft.fft(input_tensor, n=n_fft, axis=-1, norm=norm)
+    else:
+        output = array_module.fft.rfft(input_tensor, n=n_fft, axis=-1, norm=norm)
+
+    output = output.transpose((0, 2, 1))
+
+    if input_tensor_1d:
+        output = output.squeeze(0)
+
+    return output if return_complex else array_module.real(output)

--- a/faster_whisper/feature_extractor.py
+++ b/faster_whisper/feature_extractor.py
@@ -142,11 +142,11 @@ def stft(
     hop_length: int = None,
     win_length: int = None,
     window: np.ndarray = None,
-    center=True,
-    mode="reflect",
-    normalized=False,
-    onesided=None,
-    return_complex=None,
+    center: bool = True,
+    mode: str = "reflect",
+    normalized: bool = False,
+    onesided: bool = None,
+    return_complex: bool = None,
 ):
     # Default initialization for hop_length and win_length
     hop_length = hop_length if hop_length is not None else n_fft // 4

--- a/faster_whisper/feature_extractor.py
+++ b/faster_whisper/feature_extractor.py
@@ -64,7 +64,7 @@ class FeatureExtractor:
 
         return weights
 
-    def __call__(self, waveform: np.ndarray, padding=480000, chunk_length=None):
+    def __call__(self, waveform: np.ndarray, padding=160, chunk_length=None):
         """
         Compute the log-Mel spectrogram of the provided audio.
         """

--- a/faster_whisper/feature_extractor.py
+++ b/faster_whisper/feature_extractor.py
@@ -1,32 +1,15 @@
 import numpy as np
 
-try:
-    import cupy as cp
-
-    CUPY_AVAILABLE = True
-except ImportError:
-    CUPY_AVAILABLE = False
-
-
-def get_array_module(device: str = "auto"):
-    if device in ["auto", "cuda"] and CUPY_AVAILABLE and cp.cuda.is_available():
-        return cp, "cuda"
-    else:
-        return np, "cpu"
-
 
 class FeatureExtractor:
     def __init__(
         self,
-        device: str = "auto",
         feature_size=80,
         sampling_rate=16000,
         hop_length=160,
         chunk_length=30,
         n_fft=400,
     ):
-        self.array_module: np
-        self.array_module, self._device = get_array_module(device)
         self.n_fft = n_fft
         self.hop_length = hop_length
         self.chunk_length = chunk_length
@@ -38,18 +21,19 @@ class FeatureExtractor:
             sampling_rate, n_fft, n_mels=feature_size
         ).astype("float32")
 
-    def get_mel_filters(self, sr, n_fft, n_mels=128):
+    @staticmethod
+    def get_mel_filters(sr, n_fft, n_mels=128):
         # Initialize the weights
         n_mels = int(n_mels)
 
         # Center freqs of each FFT bin
-        fftfreqs = self.array_module.fft.rfftfreq(n=n_fft, d=1.0 / sr)
+        fftfreqs = np.fft.rfftfreq(n=n_fft, d=1.0 / sr)
 
         # 'Center freqs' of mel bands - uniformly spaced between limits
         min_mel = 0.0
         max_mel = 45.245640471924965
 
-        mels = self.array_module.linspace(min_mel, max_mel, n_mels + 2)
+        mels = np.linspace(min_mel, max_mel, n_mels + 2)
 
         # Fill in the linear scale
         f_min = 0.0
@@ -59,32 +43,28 @@ class FeatureExtractor:
         # And now the nonlinear scale
         min_log_hz = 1000.0  # beginning of log region (Hz)
         min_log_mel = (min_log_hz - f_min) / f_sp  # same (Mels)
-        logstep = self.array_module.log(6.4) / 27.0  # step size for log region
+        logstep = np.log(6.4) / 27.0  # step size for log region
 
         # If we have vector data, vectorize
         log_t = mels >= min_log_mel
-        freqs[log_t] = min_log_hz * self.array_module.exp(
-            logstep * (mels[log_t] - min_log_mel)
-        )
+        freqs[log_t] = min_log_hz * np.exp(logstep * (mels[log_t] - min_log_mel))
 
-        fdiff = self.array_module.diff(freqs)
+        fdiff = np.diff(freqs)
         ramps = freqs.reshape(-1, 1) - fftfreqs.reshape(1, -1)
 
-        lower = -ramps[:-2] / self.array_module.expand_dims(fdiff[:-1], axis=1)
-        upper = ramps[2:] / self.array_module.expand_dims(fdiff[1:], axis=1)
+        lower = -ramps[:-2] / np.expand_dims(fdiff[:-1], axis=1)
+        upper = ramps[2:] / np.expand_dims(fdiff[1:], axis=1)
 
         # Intersect them with each other and zero, vectorized across all i
-        weights = self.array_module.maximum(
-            self.array_module.zeros_like(lower), self.array_module.minimum(lower, upper)
-        )
+        weights = np.maximum(np.zeros_like(lower), np.minimum(lower, upper))
 
         # Slaney-style mel is scaled to be approx constant energy per channel
         enorm = 2.0 / (freqs[2 : n_mels + 2] - freqs[:n_mels])
-        weights *= self.array_module.expand_dims(enorm, axis=1)
+        weights *= np.expand_dims(enorm, axis=1)
 
         return weights
 
-    def __call__(self, waveform: np.ndarray, padding=True, chunk_length=None):
+    def __call__(self, waveform: np.ndarray, padding=480000, chunk_length=None):
         """
         Compute the log-Mel spectrogram of the provided audio.
         """
@@ -97,46 +77,29 @@ class FeatureExtractor:
             waveform = waveform.astype(np.float32)
 
         if padding:
-            waveform = np.pad(waveform, (0, self.n_samples))
+            waveform = np.pad(waveform, (0, padding))
 
-        window = self.array_module.hanning(self.n_fft + 1)[:-1].astype("float32")
+        window = np.hanning(self.n_fft + 1)[:-1].astype("float32")
 
         stft_output = stft(
-            self.array_module,
             waveform,
             self.n_fft,
             self.hop_length,
             window=window,
             return_complex=True,
         ).astype("complex64")
-        magnitudes = self.array_module.abs(stft_output[..., :-1]) ** 2
+        magnitudes = np.abs(stft_output[..., :-1]) ** 2
 
         mel_spec = self.mel_filters @ magnitudes
 
-        log_spec = self.array_module.log10(
-            self.array_module.clip(mel_spec, a_min=1e-10, a_max=None)
-        )
-        log_spec = self.array_module.maximum(log_spec, log_spec.max() - 8.0)
+        log_spec = np.log10(np.clip(mel_spec, a_min=1e-10, a_max=None))
+        log_spec = np.maximum(log_spec, log_spec.max() - 8.0)
         log_spec = (log_spec + 4.0) / 4.0
 
-        return np.asarray(log_spec.tolist(), dtype=log_spec.dtype)
-
-    @property
-    def device(self):
-        return self._device
-
-    @device.setter
-    def device(self, device):
-        if device != self.device:
-            self.array_module, self._device = get_array_module(device)
-            feature_size = self.mel_filters.shape[0]
-            self.mel_filters = self.get_mel_filters(
-                self.sampling_rate, self.n_fft, feature_size
-            ).astype("float32")
+        return log_spec
 
 
 def stft(
-    array_module: np,
     input_tensor: np.ndarray,
     n_fft: int,
     hop_length: int = None,
@@ -214,7 +177,7 @@ def stft(
     # Handle padding of the window if necessary
     if win_length < n_fft:
         left = (n_fft - win_length) // 2
-        window_ = array_module.zeros(n_fft, dtype=window.dtype)
+        window_ = np.zeros(n_fft, dtype=window.dtype)
         window_[left : left + win_length] = window
     else:
         window_ = window
@@ -234,7 +197,7 @@ def stft(
     )
 
     if window_ is not None:
-        input_tensor = array_module.asarray(input_tensor) * window_
+        input_tensor = input_tensor * window_
 
     # FFT and transpose
     complex_fft = input_is_complex
@@ -250,13 +213,13 @@ def stft(
             raise ValueError(
                 "Cannot have onesided output if window or input is complex"
             )
-        output = array_module.fft.fft(input_tensor, n=n_fft, axis=-1, norm=norm)
+        output = np.fft.fft(input_tensor, n=n_fft, axis=-1, norm=norm)
     else:
-        output = array_module.fft.rfft(input_tensor, n=n_fft, axis=-1, norm=norm)
+        output = np.fft.rfft(input_tensor, n=n_fft, axis=-1, norm=norm)
 
     output = output.transpose((0, 2, 1))
 
     if input_tensor_1d:
         output = output.squeeze(0)
 
-    return output if return_complex else array_module.real(output)
+    return output if return_complex else np.real(output)

--- a/faster_whisper/feature_extractor.py
+++ b/faster_whisper/feature_extractor.py
@@ -97,7 +97,8 @@ class FeatureExtractor:
         # Input checks
         if not np.issubdtype(input_array.dtype, np.floating) and not input_is_complex:
             raise ValueError(
-                f"stft: expected an array of floating point or complex values, got {input_array.dtype}"
+                "stft: expected an array of floating point or complex values,"
+                f" got {input_array.dtype}"
             )
 
         if input_array.ndim > 2 or input_array.ndim < 1:

--- a/faster_whisper/feature_extractor.py
+++ b/faster_whisper/feature_extractor.py
@@ -108,7 +108,7 @@ class FeatureExtractor:
             self.hop_length,
             window=window,
             return_complex=True,
-        )
+        ).astype("complex64")
         magnitudes = self.array_module.abs(stft_output[..., :-1]) ** 2
 
         mel_spec = self.mel_filters @ magnitudes
@@ -129,6 +129,10 @@ class FeatureExtractor:
     def device(self, device):
         if device != self.device:
             self.array_module, self._device = get_array_module(device)
+            feature_size = self.mel_filters.shape[0]
+            self.mel_filters = self.get_mel_filters(
+                self.sampling_rate, self.n_fft, feature_size
+            ).astype("float32")
 
 
 def stft(
@@ -144,7 +148,6 @@ def stft(
     onesided=None,
     return_complex=None,
 ):
-
     # Default initialization for hop_length and win_length
     hop_length = hop_length if hop_length is not None else n_fft // 4
     win_length = win_length if win_length is not None else n_fft

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -604,9 +604,7 @@ class WhisperModel:
                 "openai/whisper-tiny" + ("" if self.model.is_multilingual else ".en")
             )
         self.feat_kwargs = self._get_feature_kwargs(model_path, preprocessor_bytes)
-        self.feature_extractor = FeatureExtractor(
-            **self.feat_kwargs, device=self.device
-        )
+        self.feature_extractor = FeatureExtractor(**self.feat_kwargs)
         self.input_stride = 2
         self.num_samples_per_token = (
             self.feature_extractor.hop_length * self.input_stride

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -840,9 +840,7 @@ class WhisperModel:
                     if isinstance(clip_timestamps, str)
                     else clip_timestamps[0]
                 )
-                content_frames = (
-                    features.shape[-1] - self.feature_extractor.nb_max_frames
-                )
+                content_frames = features.shape[-1] - 1
                 seek = (
                     int(start_timestamp * self.frames_per_second)
                     if start_timestamp * self.frames_per_second < content_frames
@@ -1045,7 +1043,7 @@ class WhisperModel:
         options: TranscriptionOptions,
         encoder_output: Optional[ctranslate2.StorageView] = None,
     ) -> Iterable[Segment]:
-        content_frames = features.shape[-1] - self.feature_extractor.nb_max_frames
+        content_frames = features.shape[-1] - 1
         content_duration = float(content_frames * self.feature_extractor.time_per_frame)
 
         if isinstance(options.clip_timestamps, str):

--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
-import torch
 
 from faster_whisper.utils import get_assets_path
 
@@ -44,7 +43,7 @@ class VadOptions:
 
 
 def get_speech_timestamps(
-    audio: torch.Tensor,
+    audio: np.ndarray,
     vad_options: Optional[VadOptions] = None,
     sampling_rate: int = 16000,
     **kwargs,
@@ -84,7 +83,7 @@ def get_speech_timestamps(
     model = get_vad_model()
 
     padded_audio = np.pad(
-        audio.numpy(), (0, window_size_samples - audio.shape[0] % window_size_samples)
+        audio, (0, window_size_samples - audio.shape[0] % window_size_samples)
     )
     speech_probs = model(padded_audio.reshape(1, -1)).squeeze(0)
 
@@ -183,15 +182,15 @@ def get_speech_timestamps(
 
 
 def collect_chunks(
-    audio: torch.Tensor, chunks: List[dict], sampling_rate: int = 16000
-) -> Tuple[List[torch.Tensor], List[Dict[str, int]]]:
+    audio: np.ndarray, chunks: List[dict], sampling_rate: int = 16000
+) -> Tuple[List[np.ndarray], List[Dict[str, int]]]:
     """Collects audio chunks."""
     if not chunks:
         chunk_metadata = {
             "start_time": 0,
             "end_time": 0,
         }
-        return [torch.tensor([], dtype=torch.float32)], [chunk_metadata]
+        return [np.array([], dtype=np.float32)], [chunk_metadata]
 
     audio_chunks = []
     chunks_metadata = []

--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -280,7 +280,7 @@ class SileroVADModel:
     ):
         assert (
             audio.ndim == 2
-        ), "Input should be a 2D tensor with size (batch_size, num_samples)"
+        ), "Input should be a 2D array with size (batch_size, num_samples)"
         assert (
             audio.shape[1] % num_samples == 0
         ), "Input size should be a multiple of num_samples"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ ctranslate2>=4.0,<5
 huggingface_hub>=0.13
 tokenizers>=0.13,<1
 onnxruntime>=1.14,<2 
-torch>=2.1.1 
 av>=11
 tqdm

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -32,7 +32,7 @@ def test_transcribe(jfk_path):
     segment = segments[0]
 
     assert segment.text == (
-        " And so my fellow Americans ask not what your country can do for you, "
+        " And so my fellow Americans, ask not what your country can do for you, "
         "ask what you can do for your country."
     )
 
@@ -97,12 +97,12 @@ def test_prefix_with_timestamps(jfk_path):
     segment = segments[0]
 
     assert segment.text == (
-        " And so my fellow Americans ask not what your country can do for you, "
+        " And so my fellow Americans, ask not what your country can do for you, "
         "ask what you can do for your country."
     )
 
     assert segment.start == 0
-    assert 10 < segment.end < 11
+    assert 10 < segment.end <= 11
 
 
 def test_vad(jfk_path):


### PR DESCRIPTION
Hi all,

This PR aims to remove the torch dependency as it's only used for feature extraction, there are 2 options:
1. use NumPy only and scrap GPU acceleration completely, this will slightly simplify the FE code by removing the device handling and framework handling code
2. use NumPy + CuPy (the current implementation), this will allow the usage of GPU acceleration for those who want it, we still need to decide whether CuPy will be included in the base requirements or maybe as an optional requirement or none at all


These are performance figures on a 30s segment using [this](https://gist.github.com/MahmoudAshraf97/87a96999cd29efb3b6b13591b89cd1ea) script
```bash
OMP_NUM_THREADS=4 OPENBLAS_NUM_THREADS=4 MKL_NUM_THREADS=4 VECLIB_MAXIMUM_THREADS=4 NUMEXPR_NUM_THREADS=4 taskset -c 0-3 python benchmark_fe.py
```
```
Cores: {0, 1, 2, 3}
Torch on CPU:
5.66 ms
Torch on GPU:
0.71 ms
New numpy on CPU:
10.36 ms
New CuPY on GPU:
2.19 ms
Old numpy on CPU:
39.55 ms
```
edit: Decided to remove CuPy as the speed difference is not worth the extra code
