### PR TITLE
Update audio.py

### DIFF
--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -1,20 +1,65 @@
-"""We use the PyAV library to decode the audio: https://github.com/PyAV-Org/PyAV
-
-The advantage of PyAV is that it bundles the FFmpeg libraries so there is no additional
-system dependencies. FFmpeg does not need to be installed on the system.
-
-However, the API is quite low-level so we need to manipulate audio frames directly.
+"""We use system FFmpeg when available for faster audio decoding. As a fallback, we use
+the PyAV library: https://github.com/PyAV-Org/PyAV
+If FFmpeg is installed on the system, we use it directly for optimal performance.
+If FFmpeg is not available, PyAV provides the advantage of bundled FFmpeg libraries,
+though its low-level API requires direct frame manipulation.
 """
-
 import gc
 import io
 import itertools
-
+import subprocess
+import tempfile
 from typing import BinaryIO, Union
 
 import av
 import numpy as np
 import torch
+
+
+def is_ffmpeg_available() -> bool:
+    try:
+        subprocess.check_output(["ffmpeg", "-version"])
+        return True
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
+
+
+def decode_audio_ffmpeg(
+    input_file: Union[str, BinaryIO],
+    sampling_rate: int = 16000,
+    split_stereo: bool = False,
+):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = f"{tmpdir}/temp.wav"
+        channels = 2 if split_stereo else 1
+
+        cmd = [
+            "ffmpeg",
+            "-i",
+            str(input_file),
+            "-ar",
+            str(sampling_rate),
+            "-ac",
+            str(channels),
+            "-acodec",
+            "pcm_s16le",
+            output_file,
+            "-y",
+        ]
+
+        try:
+            subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            audio = np.fromfile(output_file, dtype=np.int16)
+            audio = audio.astype(np.float32) / 32768.0
+
+            if split_stereo:
+                left_channel = audio[0::2]
+                right_channel = audio[1::2]
+                return torch.from_numpy(left_channel), torch.from_numpy(right_channel)
+            return torch.from_numpy(audio)
+
+        except subprocess.SubprocessError:
+            raise RuntimeError("FFmpeg failed to decode the audio file")
 
 
 def decode_audio(
@@ -25,16 +70,21 @@ def decode_audio(
     """Decodes the audio.
 
     Args:
-      input_file: Path to the input file or a file-like object.
-      sampling_rate: Resample the audio to this sample rate.
-      split_stereo: Return separate left and right channels.
+        input_file: Path to the input file or a file-like object.
+        sampling_rate: Resample the audio to this sample rate.
+        split_stereo: Return separate left and right channels.
 
     Returns:
-      A float32 Numpy array.
-
-      If `split_stereo` is enabled, the function returns a 2-tuple with the
-      separated left and right channels.
+        A float32 Numpy array.
+        If `split_stereo` is enabled, the function returns a 2-tuple with the
+        separated left and right channels.
     """
+    if is_ffmpeg_available():
+        try:
+            return decode_audio_ffmpeg(input_file, sampling_rate, split_stereo)
+        except:
+            pass
+
     resampler = av.audio.resampler.AudioResampler(
         format="s16",
         layout="mono" if not split_stereo else "stereo",
@@ -46,10 +96,9 @@ def decode_audio(
 
     with av.open(input_file, mode="r", metadata_errors="ignore") as container:
         frames = container.decode(audio=0)
-        frames = _ignore_invalid_frames(frames)
-        frames = _group_frames(frames, 500000)
-        frames = _resample_frames(frames, resampler)
-
+        frames = ignore_invalid_frames(frames)
+        frames = group_frames(frames, 500000)
+        frames = resample_frames(frames, resampler)
         for frame in frames:
             array = frame.to_ndarray()
             dtype = array.dtype
@@ -65,7 +114,6 @@ def decode_audio(
     gc.collect()
 
     audio = np.frombuffer(raw_buffer.getbuffer(), dtype=dtype)
-
     # Convert s16 back to f32.
     audio = audio.astype(np.float32) / 32768.0
 
@@ -73,13 +121,11 @@ def decode_audio(
         left_channel = audio[0::2]
         right_channel = audio[1::2]
         return torch.from_numpy(left_channel), torch.from_numpy(right_channel)
-
     return torch.from_numpy(audio)
 
 
-def _ignore_invalid_frames(frames):
+def ignore_invalid_frames(frames):
     iterator = iter(frames)
-
     while True:
         try:
             yield next(iterator)
@@ -89,44 +135,32 @@ def _ignore_invalid_frames(frames):
             continue
 
 
-def _group_frames(frames, num_samples=None):
+def group_frames(frames, num_samples=None):
     fifo = av.audio.fifo.AudioFifo()
-
     for frame in frames:
         frame.pts = None  # Ignore timestamp check.
         fifo.write(frame)
-
         if num_samples is not None and fifo.samples >= num_samples:
             yield fifo.read()
-
     if fifo.samples > 0:
         yield fifo.read()
 
 
-def _resample_frames(frames, resampler):
+def resample_frames(frames, resampler):
     # Add None to flush the resampler.
     for frame in itertools.chain(frames, [None]):
         yield from resampler.resample(frame)
 
 
 def pad_or_trim(array, length: int = 3000, *, axis: int = -1):
-    """
-    Pad or trim the Mel features array to 3000, as expected by the encoder.
-    """
+    """Pad or trim the Mel features array to 3000, as expected by the encoder."""
     axis = axis % array.ndim
     if array.shape[axis] > length:
         idx = [Ellipsis] * axis + [slice(length)] + [Ellipsis] * (array.ndim - axis - 1)
         return array[idx]
 
     if array.shape[axis] < length:
-        pad_widths = (
-            [
-                0,
-            ]
-            * array.ndim
-            * 2
-        )
+        pad_widths = ([0] * array.ndim * 2)
         pad_widths[2 * axis] = length - array.shape[axis]
         array = torch.nn.functional.pad(array, tuple(pad_widths[::-1]))
-
     return array

--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -17,144 +17,146 @@ import torch
 
 
 def is_ffmpeg_available() -> bool:
-   try:
-       subprocess.check_output(["ffmpeg", "-version"])
-       return True
-   except (subprocess.SubprocessError, FileNotFoundError):
-       return False
+    try:
+        subprocess.check_output(["ffmpeg", "-version"])
+        return True
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
 
 
-def decode_audio_ffmpeg(input_file: Union[str, BinaryIO], sampling_rate: int = 16000, split_stereo: bool = False):
-   with tempfile.TemporaryDirectory() as tmpdir:
-       output_file = f"{tmpdir}/temp.wav"
-       channels = 2 if split_stereo else 1
+def decode_audio_ffmpeg(
+    input_file: Union[str, BinaryIO], sampling_rate: int = 16000, split_stereo: bool = False
+):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = f"{tmpdir}/temp.wav"
+        channels = 2 if split_stereo else 1
 
-       cmd = [
-           "ffmpeg",
-           "-i",
-           str(input_file),
-           "-ar",
-           str(sampling_rate),
-           "-ac",
-           str(channels),
-           "-acodec",
-           "pcm_s16le",
-           output_file,
-           "-y",
-       ]
+        cmd = [
+            "ffmpeg",
+            "-i",
+            str(input_file),
+            "-ar",
+            str(sampling_rate),
+            "-ac",
+            str(channels),
+            "-acodec",
+            "pcm_s16le",
+            output_file,
+            "-y",
+        ]
 
-       try:
-           subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-           audio = np.fromfile(output_file, dtype=np.int16)
-           audio = audio.astype(np.float32) / 32768.0
+        try:
+            subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            audio = np.fromfile(output_file, dtype=np.int16)
+            audio = audio.astype(np.float32) / 32768.0
 
-           if split_stereo:
-               left_channel = audio[0::2]
-               right_channel = audio[1::2]
-               return torch.from_numpy(left_channel), torch.from_numpy(right_channel)
-           return torch.from_numpy(audio)
+            if split_stereo:
+                left_channel = audio[0::2]
+                right_channel = audio[1::2]
+                return torch.from_numpy(left_channel), torch.from_numpy(right_channel)
+            return torch.from_numpy(audio)
 
-       except subprocess.SubprocessError:
-           raise RuntimeError("FFmpeg failed to decode the audio file")
+        except subprocess.SubprocessError:
+            raise RuntimeError("FFmpeg failed to decode the audio file")
 
 
 def decode_audio(
-   input_file: Union[str, BinaryIO], sampling_rate: int = 16000, split_stereo: bool = False
+    input_file: Union[str, BinaryIO], sampling_rate: int = 16000, split_stereo: bool = False
 ):
-   """Decodes the audio.
+    """Decodes the audio.
 
-   Args:
-       input_file: Path to the input file or a file-like object.
-       sampling_rate: Resample the audio to this sample rate.
-       split_stereo: Return separate left and right channels.
+    Args:
+        input_file: Path to the input file or a file-like object.
+        sampling_rate: Resample the audio to this sample rate.
+        split_stereo: Return separate left and right channels.
 
-   Returns:
-       A float32 Numpy array.
-       If `split_stereo` is enabled, the function returns a 2-tuple with the
-       separated left and right channels.
-   """
-   if is_ffmpeg_available():
-       try:
-           return decode_audio_ffmpeg(input_file, sampling_rate, split_stereo)
-       except (subprocess.SubprocessError, RuntimeError):
-           pass
+    Returns:
+        A float32 Numpy array.
+        If `split_stereo` is enabled, the function returns a 2-tuple with the
+        separated left and right channels.
+    """
+    if is_ffmpeg_available():
+        try:
+            return decode_audio_ffmpeg(input_file, sampling_rate, split_stereo)
+        except (subprocess.SubprocessError, RuntimeError):
+            pass
 
-   resampler = av.audio.resampler.AudioResampler(
-       format="s16",
-       layout="mono" if not split_stereo else "stereo",
-       rate=sampling_rate,
-   )
+    resampler = av.audio.resampler.AudioResampler(
+        format="s16",
+        layout="mono" if not split_stereo else "stereo",
+        rate=sampling_rate,
+    )
 
-   raw_buffer = io.BytesIO()
-   dtype = None
+    raw_buffer = io.BytesIO()
+    dtype = None
 
-   with av.open(input_file, mode="r", metadata_errors="ignore") as container:
-       frames = container.decode(audio=0)
-       frames = ignore_invalid_frames(frames)
-       frames = group_frames(frames, 500000)
-       frames = resample_frames(frames, resampler)
-       for frame in frames:
-           array = frame.to_ndarray()
-           dtype = array.dtype
-           raw_buffer.write(array)
+    with av.open(input_file, mode="r", metadata_errors="ignore") as container:
+        frames = container.decode(audio=0)
+        frames = ignore_invalid_frames(frames)
+        frames = group_frames(frames, 500000)
+        frames = resample_frames(frames, resampler)
+        for frame in frames:
+            array = frame.to_ndarray()
+            dtype = array.dtype
+            raw_buffer.write(array)
 
-   # It appears that some objects related to the resampler are not freed
-   # unless the garbage collector is manually run.
-   # https://github.com/SYSTRAN/faster-whisper/issues/390
-   # note that this slows down loading the audio a little bit
-   # if that is a concern, please use ffmpeg directly as in here:
-   # https://github.com/openai/whisper/blob/25639fc/whisper/audio.py#L25-L62
-   del resampler
-   gc.collect()
+    # It appears that some objects related to the resampler are not freed
+    # unless the garbage collector is manually run.
+    # https://github.com/SYSTRAN/faster-whisper/issues/390
+    # note that this slows down loading the audio a little bit
+    # if that is a concern, please use ffmpeg directly as in here:
+    # https://github.com/openai/whisper/blob/25639fc/whisper/audio.py#L25-L62
+    del resampler
+    gc.collect()
 
-   audio = np.frombuffer(raw_buffer.getbuffer(), dtype=dtype)
-   # Convert s16 back to f32.
-   audio = audio.astype(np.float32) / 32768.0
+    audio = np.frombuffer(raw_buffer.getbuffer(), dtype=dtype)
+    # Convert s16 back to f32.
+    audio = audio.astype(np.float32) / 32768.0
 
-   if split_stereo:
-       left_channel = audio[0::2]
-       right_channel = audio[1::2]
-       return torch.from_numpy(left_channel), torch.from_numpy(right_channel)
-   return torch.from_numpy(audio)
+    if split_stereo:
+        left_channel = audio[0::2]
+        right_channel = audio[1::2]
+        return torch.from_numpy(left_channel), torch.from_numpy(right_channel)
+    return torch.from_numpy(audio)
 
 
 def ignore_invalid_frames(frames):
-   iterator = iter(frames)
-   while True:
-       try:
-           yield next(iterator)
-       except StopIteration:
-           break
-       except av.error.InvalidDataError:
-           continue
+    iterator = iter(frames)
+    while True:
+        try:
+            yield next(iterator)
+        except StopIteration:
+            break
+        except av.error.InvalidDataError:
+            continue
 
 
 def group_frames(frames, num_samples=None):
-   fifo = av.audio.fifo.AudioFifo()
-   for frame in frames:
-       frame.pts = None  # Ignore timestamp check.
-       fifo.write(frame)
-       if num_samples is not None and fifo.samples >= num_samples:
-           yield fifo.read()
-   if fifo.samples > 0:
-       yield fifo.read()
+    fifo = av.audio.fifo.AudioFifo()
+    for frame in frames:
+        frame.pts = None  # Ignore timestamp check.
+        fifo.write(frame)
+        if num_samples is not None and fifo.samples >= num_samples:
+            yield fifo.read()
+    if fifo.samples > 0:
+        yield fifo.read()
 
 
 def resample_frames(frames, resampler):
-   # Add None to flush the resampler.
-   for frame in itertools.chain(frames, [None]):
-       yield from resampler.resample(frame)
+    # Add None to flush the resampler.
+    for frame in itertools.chain(frames, [None]):
+        yield from resampler.resample(frame)
 
 
 def pad_or_trim(array, length: int = 3000, *, axis: int = -1):
-   """Pad or trim the Mel features array to 3000, as expected by the encoder."""
-   axis = axis % array.ndim
-   if array.shape[axis] > length:
-       idx = [Ellipsis] * axis + [slice(length)] + [Ellipsis] * (array.ndim - axis - 1)
-       return array[idx]
+    """Pad or trim the Mel features array to 3000, as expected by the encoder."""
+    axis = axis % array.ndim
+    if array.shape[axis] > length:
+        idx = [Ellipsis] * axis + [slice(length)] + [Ellipsis] * (array.ndim - axis - 1)
+        return array[idx]
 
-   if array.shape[axis] < length:
-       pad_widths = [0] * array.ndim * 2
-       pad_widths[2 * axis] = length - array.shape[axis]
-       array = torch.nn.functional.pad(array, tuple(pad_widths[::-1]))
-   return array
+    if array.shape[axis] < length:
+        pad_widths = [0] * array.ndim * 2
+        pad_widths[2 * axis] = length - array.shape[axis]
+        array = torch.nn.functional.pad(array, tuple(pad_widths[::-1]))
+    return array

--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -4,13 +4,11 @@ If FFmpeg is installed on the system, we use it directly for optimal performance
 If FFmpeg is not available, PyAV provides the advantage of bundled FFmpeg libraries,
 though its low-level API requires direct frame manipulation.
 """
-
 import gc
 import io
 import itertools
 import subprocess
 import tempfile
-
 from typing import BinaryIO, Union
 
 import av

--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -17,150 +17,144 @@ import torch
 
 
 def is_ffmpeg_available() -> bool:
-    try:
-        subprocess.check_output(["ffmpeg", "-version"])
-        return True
-    except (subprocess.SubprocessError, FileNotFoundError):
-        return False
+   try:
+       subprocess.check_output(["ffmpeg", "-version"])
+       return True
+   except (subprocess.SubprocessError, FileNotFoundError):
+       return False
 
 
-def decode_audio_ffmpeg(
-    input_file: Union[str, BinaryIO],
-    sampling_rate: int = 16000,
-    split_stereo: bool = False,
-):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        output_file = f"{tmpdir}/temp.wav"
-        channels = 2 if split_stereo else 1
+def decode_audio_ffmpeg(input_file: Union[str, BinaryIO], sampling_rate: int = 16000, split_stereo: bool = False):
+   with tempfile.TemporaryDirectory() as tmpdir:
+       output_file = f"{tmpdir}/temp.wav"
+       channels = 2 if split_stereo else 1
 
-        cmd = [
-            "ffmpeg",
-            "-i",
-            str(input_file),
-            "-ar",
-            str(sampling_rate),
-            "-ac",
-            str(channels),
-            "-acodec",
-            "pcm_s16le",
-            output_file,
-            "-y",
-        ]
+       cmd = [
+           "ffmpeg",
+           "-i",
+           str(input_file),
+           "-ar",
+           str(sampling_rate),
+           "-ac",
+           str(channels),
+           "-acodec",
+           "pcm_s16le",
+           output_file,
+           "-y",
+       ]
 
-        try:
-            subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            audio = np.fromfile(output_file, dtype=np.int16)
-            audio = audio.astype(np.float32) / 32768.0
+       try:
+           subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+           audio = np.fromfile(output_file, dtype=np.int16)
+           audio = audio.astype(np.float32) / 32768.0
 
-            if split_stereo:
-                left_channel = audio[0::2]
-                right_channel = audio[1::2]
-                return torch.from_numpy(left_channel), torch.from_numpy(right_channel)
-            return torch.from_numpy(audio)
+           if split_stereo:
+               left_channel = audio[0::2]
+               right_channel = audio[1::2]
+               return torch.from_numpy(left_channel), torch.from_numpy(right_channel)
+           return torch.from_numpy(audio)
 
-        except subprocess.SubprocessError:
-            raise RuntimeError("FFmpeg failed to decode the audio file")
+       except subprocess.SubprocessError:
+           raise RuntimeError("FFmpeg failed to decode the audio file")
 
 
 def decode_audio(
-    input_file: Union[str, BinaryIO],
-    sampling_rate: int = 16000,
-    split_stereo: bool = False,
+   input_file: Union[str, BinaryIO], sampling_rate: int = 16000, split_stereo: bool = False
 ):
-    """Decodes the audio.
+   """Decodes the audio.
 
-    Args:
-        input_file: Path to the input file or a file-like object.
-        sampling_rate: Resample the audio to this sample rate.
-        split_stereo: Return separate left and right channels.
+   Args:
+       input_file: Path to the input file or a file-like object.
+       sampling_rate: Resample the audio to this sample rate.
+       split_stereo: Return separate left and right channels.
 
-    Returns:
-        A float32 Numpy array.
-        If `split_stereo` is enabled, the function returns a 2-tuple with the
-        separated left and right channels.
-    """
-    if is_ffmpeg_available():
-        try:
-            return decode_audio_ffmpeg(input_file, sampling_rate, split_stereo)
-        except (subprocess.SubprocessError, RuntimeError):
-            pass
+   Returns:
+       A float32 Numpy array.
+       If `split_stereo` is enabled, the function returns a 2-tuple with the
+       separated left and right channels.
+   """
+   if is_ffmpeg_available():
+       try:
+           return decode_audio_ffmpeg(input_file, sampling_rate, split_stereo)
+       except (subprocess.SubprocessError, RuntimeError):
+           pass
 
-    resampler = av.audio.resampler.AudioResampler(
-        format="s16",
-        layout="mono" if not split_stereo else "stereo",
-        rate=sampling_rate,
-    )
+   resampler = av.audio.resampler.AudioResampler(
+       format="s16",
+       layout="mono" if not split_stereo else "stereo",
+       rate=sampling_rate,
+   )
 
-    raw_buffer = io.BytesIO()
-    dtype = None
+   raw_buffer = io.BytesIO()
+   dtype = None
 
-    with av.open(input_file, mode="r", metadata_errors="ignore") as container:
-        frames = container.decode(audio=0)
-        frames = ignore_invalid_frames(frames)
-        frames = group_frames(frames, 500000)
-        frames = resample_frames(frames, resampler)
-        for frame in frames:
-            array = frame.to_ndarray()
-            dtype = array.dtype
-            raw_buffer.write(array)
+   with av.open(input_file, mode="r", metadata_errors="ignore") as container:
+       frames = container.decode(audio=0)
+       frames = ignore_invalid_frames(frames)
+       frames = group_frames(frames, 500000)
+       frames = resample_frames(frames, resampler)
+       for frame in frames:
+           array = frame.to_ndarray()
+           dtype = array.dtype
+           raw_buffer.write(array)
 
-    # It appears that some objects related to the resampler are not freed
-    # unless the garbage collector is manually run.
-    # https://github.com/SYSTRAN/faster-whisper/issues/390
-    # note that this slows down loading the audio a little bit
-    # if that is a concern, please use ffmpeg directly as in here:
-    # https://github.com/openai/whisper/blob/25639fc/whisper/audio.py#L25-L62
-    del resampler
-    gc.collect()
+   # It appears that some objects related to the resampler are not freed
+   # unless the garbage collector is manually run.
+   # https://github.com/SYSTRAN/faster-whisper/issues/390
+   # note that this slows down loading the audio a little bit
+   # if that is a concern, please use ffmpeg directly as in here:
+   # https://github.com/openai/whisper/blob/25639fc/whisper/audio.py#L25-L62
+   del resampler
+   gc.collect()
 
-    audio = np.frombuffer(raw_buffer.getbuffer(), dtype=dtype)
-    # Convert s16 back to f32.
-    audio = audio.astype(np.float32) / 32768.0
+   audio = np.frombuffer(raw_buffer.getbuffer(), dtype=dtype)
+   # Convert s16 back to f32.
+   audio = audio.astype(np.float32) / 32768.0
 
-    if split_stereo:
-        left_channel = audio[0::2]
-        right_channel = audio[1::2]
-        return torch.from_numpy(left_channel), torch.from_numpy(right_channel)
-    return torch.from_numpy(audio)
+   if split_stereo:
+       left_channel = audio[0::2]
+       right_channel = audio[1::2]
+       return torch.from_numpy(left_channel), torch.from_numpy(right_channel)
+   return torch.from_numpy(audio)
 
 
 def ignore_invalid_frames(frames):
-    iterator = iter(frames)
-    while True:
-        try:
-            yield next(iterator)
-        except StopIteration:
-            break
-        except av.error.InvalidDataError:
-            continue
+   iterator = iter(frames)
+   while True:
+       try:
+           yield next(iterator)
+       except StopIteration:
+           break
+       except av.error.InvalidDataError:
+           continue
 
 
 def group_frames(frames, num_samples=None):
-    fifo = av.audio.fifo.AudioFifo()
-    for frame in frames:
-        frame.pts = None  # Ignore timestamp check.
-        fifo.write(frame)
-        if num_samples is not None and fifo.samples >= num_samples:
-            yield fifo.read()
-    if fifo.samples > 0:
-        yield fifo.read()
+   fifo = av.audio.fifo.AudioFifo()
+   for frame in frames:
+       frame.pts = None  # Ignore timestamp check.
+       fifo.write(frame)
+       if num_samples is not None and fifo.samples >= num_samples:
+           yield fifo.read()
+   if fifo.samples > 0:
+       yield fifo.read()
 
 
 def resample_frames(frames, resampler):
-    # Add None to flush the resampler.
-    for frame in itertools.chain(frames, [None]):
-        yield from resampler.resample(frame)
+   # Add None to flush the resampler.
+   for frame in itertools.chain(frames, [None]):
+       yield from resampler.resample(frame)
 
 
 def pad_or_trim(array, length: int = 3000, *, axis: int = -1):
-    """Pad or trim the Mel features array to 3000, as expected by the encoder."""
-    axis = axis % array.ndim
-    if array.shape[axis] > length:
-        idx = [Ellipsis] * axis + [slice(length)] + [Ellipsis] * (array.ndim - axis - 1)
-        return array[idx]
+   """Pad or trim the Mel features array to 3000, as expected by the encoder."""
+   axis = axis % array.ndim
+   if array.shape[axis] > length:
+       idx = [Ellipsis] * axis + [slice(length)] + [Ellipsis] * (array.ndim - axis - 1)
+       return array[idx]
 
-    if array.shape[axis] < length:
-        pad_widths = ([0] * array.ndim * 2)
-        pad_widths[2 * axis] = length - array.shape[axis]
-        array = torch.nn.functional.pad(array, tuple(pad_widths[::-1]))
-    return array
+   if array.shape[axis] < length:
+       pad_widths = [0] * array.ndim * 2
+       pad_widths[2 * axis] = length - array.shape[axis]
+       array = torch.nn.functional.pad(array, tuple(pad_widths[::-1]))
+   return array

--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -4,11 +4,13 @@ If FFmpeg is installed on the system, we use it directly for optimal performance
 If FFmpeg is not available, PyAV provides the advantage of bundled FFmpeg libraries,
 though its low-level API requires direct frame manipulation.
 """
+
 import gc
 import io
 import itertools
 import subprocess
 import tempfile
+
 from typing import BinaryIO, Union
 
 import av

--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -82,7 +82,7 @@ def decode_audio(
     if is_ffmpeg_available():
         try:
             return decode_audio_ffmpeg(input_file, sampling_rate, split_stereo)
-        except:
+        except (subprocess.SubprocessError, RuntimeError):
             pass
 
     resampler = av.audio.resampler.AudioResampler(


### PR DESCRIPTION
This re-introduces FFMPEG binary, which is much faster than AV (which bundles FFMPEG), to decode audio.  It will only use FFMPEG directly if it's available; otherwise, it'll use AV just like before. Thus, there should be no impact whatsoever for users who traditionally don't install FFMPEG separately to use `faster-whisper`...while people who have FFMPEG somewhere on their system (as many do) will enjoy a nice speedup.

<details>
<summary>BENCHMARK comparison</summary>

## Pydub Backend:
1. **File Opening and Initial Setup** took **13.520851** seconds. Entire audio file loaded into memory.
2. **Decoding and Resampling** took **4.008535** seconds. Resampling and channel conversion performed in-memory.
3. **Converting to Numpy Array** took **0.312081** seconds. Audio data converted to numpy array and normalized.

**convert_pydub** took **17.846182** seconds

## AV Backend:
1. **File Opening and Initial Setup** took **0.002802** seconds. File header opened and resampler created. Audio data not yet loaded.
2. **Decoding and Resampling** took **6.407928** seconds. Audio data read, decoded, and resampled in chunks.
3. **Converting to Numpy Array** took **2.538944** seconds. Processed audio frames converted to numpy array and normalized.

**convert_av** took **9.008320** seconds

## FFmpeg Backend:
1. **File Opening and Initial Setup** took **0.000850** seconds. Temporary WAV file created.
2. **Decoding and Resampling** took **1.736469** seconds. Input file converted to WAV format using FFmpeg.
3. **Converting to Numpy Array** took **0.320413** seconds. WAV file read, converted to numpy array, and normalized.

**convert_ffmpeg** took **2.072908** seconds

</details>

This benchmark was done using the Sam Altman podcast, which is over two hours long.  Used an RTX 4090 + 13900k.  Obviously, the "actual" seconds saved will be less for smaller files...But with that being said, if batch processing is used and/or large files are in-fact processed, the "relative" speedup by using FFMPEG is stark.

Again, ```faster-whisper```'s reliance on ```AV``` would not change, but there would simply be an option now to use FFMPEG directly via ```sub-process```.

```Pydub```, another backend, is show for comparison only.  Here's the benchmark script...just add a different file name to test something different:

<details><summary>BENCH SCRIPT HERE</summary>

```
import numpy as np
import time
import os
from pydub import AudioSegment
import av
import subprocess
import tempfile

# ANSI escape code for green text
GREEN = '\033[92m'
RESET = '\033[0m'

def timeit(func):
    def wrapper(*args, **kwargs):
        start = time.perf_counter()
        result = func(*args, **kwargs)
        end = time.perf_counter()
        print(f"{GREEN}{func.__name__} took {end - start:.6f} seconds{RESET}")
        return result
    return wrapper

class AudioConverter:
    def __init__(self, input_file):
        self.input_file = input_file
        self.base_name = os.path.splitext(os.path.basename(input_file))[0]

    def time_step(self, step_name):
        start = time.perf_counter()
        return start, step_name

    def end_step(self, start, step_name, additional_info=""):
        end = time.perf_counter()
        print(f"{step_name} took {end - start:.6f} seconds. {additional_info}")

    @timeit
    def convert_pydub(self):
        """
        This method:
        1. Loads the entire audio file into memory.
            - "AudioSegment.from_file()" initially loads the entire file into memory
        2. Performs resampling and channel conversion in-memory.
        3. Converts the audio data to a numpy array.

        Note: The initial loading time includes file reading and decoding.
        """
        start, step = self.time_step("1. File Opening and Initial Setup")
        audio = AudioSegment.from_file(self.input_file)
        self.end_step(start, step, "Entire audio file loaded into memory.")

        start, step = self.time_step("2. Decoding and Resampling")
        audio = audio.set_frame_rate(16000).set_channels(1)
        self.end_step(start, step, "Resampling and channel conversion performed in-memory.")

        start, step = self.time_step("3. Converting to Numpy Array")
        result = np.array(audio.get_array_of_samples()).astype(np.float32) / np.iinfo(np.int16).max
        self.end_step(start, step, "Audio data converted to numpy array and normalized.")

        return result

    @timeit
    def convert_av(self):
        """
        This method:
        1. Opens the audio file without loading it entirely into memory.
            - "container.decode(audio)" yields frames one at a time, allowing for true streaming processing without loading the entire file into memory
        2. Creates a resampler for the desired output format.
        3. Processes the audio in chunks, decoding and resampling each chunk.
        4. Concatenates the processed chunks into a numpy array.

        Note: The decoding and resampling step includes the actual reading and processing of the audio data.
        """
        start, step = self.time_step("1. File Opening and Initial Setup")
        container = av.open(self.input_file)
        audio = container.streams.audio[0]
        resampler = av.audio.resampler.AudioResampler(
            format='s16',
            layout='mono',
            rate=16000
        )
        self.end_step(start, step, "File header opened and resampler created. Audio data not yet loaded.")

        start, step = self.time_step("2. Decoding and Resampling")
        audio_frames = []
        for frame in container.decode(audio):
            resampled_frames = resampler.resample(frame)
            for resampled_frame in resampled_frames:
                audio_frames.append(resampled_frame)
        self.end_step(start, step, "Audio data read, decoded, and resampled in chunks.")

        start, step = self.time_step("3. Converting to Numpy Array")
        if not audio_frames:
            result = np.array([])
        else:
            result = np.concatenate([frame.to_ndarray().flatten() for frame in audio_frames]).astype(np.float32) / np.iinfo(np.int16).max
        self.end_step(start, step, "Processed audio frames converted to numpy array and normalized.")

        return result

    @timeit
    def convert_ffmpeg(self):
        """
        This method:
        1. Creates a temporary WAV file.
        2. Uses FFmpeg to convert the input to the temporary WAV file.
        3. Reads the temporary WAV file and converts it to a numpy array.

        Note: This method first converts the input to a WAV file before processing, 
        which can add overhead but ensures a consistent input format.
        """
        if self.input_file.endswith('.wav'):
            return self.to_np(self.input_file)
        else:
            start, step = self.time_step("1. File Opening and Initial Setup")
            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as temp_file:
                temp_file_path = temp_file.name
            self.end_step(start, step, "Temporary WAV file created.")

            try:
                start, step = self.time_step("2. Decoding and Resampling")
                subprocess.run([
                    'ffmpeg', '-i', self.input_file, '-ac', '1', '-ar', '16000',
                    temp_file_path, '-y'
                ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                self.end_step(start, step, "Input file converted to WAV format using FFmpeg.")

                return self.to_np(temp_file_path)
            finally:
                os.remove(temp_file_path)

    def to_np(self, file_path):
        start, step = self.time_step("3. Converting to Numpy Array")
        with open(file_path, 'rb') as f:
            header = f.read(44)
            raw_data = f.read()
        samples = np.frombuffer(raw_data, dtype=np.int16)
        result = samples.astype(np.float32) / np.iinfo(np.int16).max
        self.end_step(start, step, "WAV file read, converted to numpy array, and normalized.")

        return result

def benchmark(input_file):
    converter = AudioConverter(input_file)
    
    print("\nPydub Backend:")
    pydub_array = converter.convert_pydub()

    print("\nAV Backend:")
    av_array = converter.convert_av()

    print("\nFFmpeg Backend:")
    ffmpeg_array = converter.convert_ffmpeg()

if __name__ == "__main__":
    input_file = r"D:\Scripts\bench_cupy\test1.flac"
    benchmark(input_file)
```
</details>