### PR TITLE
Added encoder output

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -114,6 +114,7 @@ class TranscriptionInfo:
     transcription_options: TranscriptionOptions
     vad_options: VadOptions
 
+
 @dataclass
 class TranscriptionResult:
     segments: Iterable["Segment"]


### PR DESCRIPTION
`WhisperModel` now also outputs encoder embeddings optionally.

Usage:
normal, backwards compatible:
```py
segments, info = model.transcribe(audio_path, beam_size=1)
```

for encoder outputs:
```py
segments, info, encoder_output = model.transcribe(audio_path, beam_size=1).all()
```


Usage is fully backwards compatible