### PR TITLE
Deduplication of language detection functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,17 +164,6 @@ segments, _ = model.transcribe("audio.mp3")
 segments = list(segments)  # The transcription will actually run here.
 ```
 
-### Multi-Segment Language Detection
-
-To directly use the model for improved language detection, the following code snippet can be used:
-
-```python
-from faster_whisper import WhisperModel
-
-model = WhisperModel("turbo", device="cuda", compute_type="float16")
-language_info = model.detect_language_multi_segment("audio.mp3")
-```
-
 ### Batched Transcription
 The following code snippet illustrates how to run batched transcription on an example audio file. `BatchedInferencePipeline.transcribe` is a drop-in replacement for `WhisperModel.transcribe`
 

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -384,7 +384,7 @@ class BatchedInferencePipeline:
                     language_probability,
                     all_language_probs,
                 ) = self.model.detect_language(
-                    features=np.concatenate(list(features), axis=1),
+                    features=np.concatenate(features, axis=1),
                     language_detection_segments=language_detection_segments,
                     language_detection_threshold=language_detection_threshold,
                 )

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,5 +1,7 @@
 import os
 
+import numpy as np
+
 from faster_whisper import BatchedInferencePipeline, WhisperModel, decode_audio
 from faster_whisper.tokenizer import Tokenizer
 from faster_whisper.transcribe import get_suppressed_tokens
@@ -85,6 +87,15 @@ def test_batched_transcribe(physcisworks_path):
             {"start": segment.start, "end": segment.end, "text": segment.text}
         )
     assert len(segments) > 7
+
+
+def test_empty_audio():
+    audio = np.asarray([], dtype="float32")
+    model = WhisperModel("tiny")
+    pipeline = BatchedInferencePipeline(model=model)
+    assert list(model.transcribe(audio)[0]) == []
+    assert list(pipeline.transcribe(audio)[0]) == []
+    model.detect_language(audio)
 
 
 def test_prefix_with_timestamps(jfk_path):

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -147,13 +147,6 @@ def test_stereo_diarization(data_dir):
     assert transcription == "The horizon seems extremely distant."
 
 
-def test_multisegment_lang_id(physcisworks_path):
-    model = WhisperModel("tiny")
-    language_info = model.detect_language_multi_segment(physcisworks_path)
-    assert language_info["language_code"] == "en"
-    assert language_info["language_confidence"] > 0.8
-
-
 def test_suppressed_tokens_minus_1():
     model = WhisperModel("tiny.en")
 


### PR DESCRIPTION
This PR aims to unify language detection in both `WhisperModel` and `BatchedInferencePipeline`

Summary:
* Supported new options for batched transcriptions:
  * `language_detection_threshold`
  * `language_detection_segments`
* Updated `WhisperModel.detect_language` function to include the improved language detection from #732  and added docstrings, it's now used inside `transcribe` function.
* Removed the following functions as they are no longer needed:
  * `WhisperModel.detect_language_multi_segment` and its test
  * `BatchedInferencePipeline.get_language_and_tokenizer`
* Added tests for empty audios