### PR TITLE
Update vad.py with more sane speech_pad_ms: int = 4000

### DIFF
--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -39,7 +39,7 @@ class VadOptions:
     min_speech_duration_ms: int = 0
     max_speech_duration_s: float = float("inf")
     min_silence_duration_ms: int = 2000
-    speech_pad_ms: int = 400
+    speech_pad_ms: int = 4000
 
 
 def get_speech_timestamps(


### PR DESCRIPTION
In all my tests speech_pad_ms: int = 400 was too small. All other VAD numbers were good. Making speech_pad_ms: int = 4000 2x the min_silence_duration_ms: int = 2000 fixed all my problems. Maybe someone forgot to add another 0?

Here it is doubled too:
https://github.com/jhj0517/Whisper-WebUI/blob/master/configs/default_parameters.yaml
vad:
  vad_filter: false
  threshold: 0.5
  min_speech_duration_ms: 250
  max_speech_duration_s: 9999
  min_silence_duration_ms: 1000
  speech_pad_ms: 2000