### PR TITLE
constraint tokenizers version for python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 ctranslate2>=4.0,<5
 huggingface_hub>=0.13
-tokenizers>=0.13,<1
-onnxruntime>=1.14,<2 
+tokenizers>=0.13,<1; python_version != "3.8"
+tokenizers>=0.13,<0.20.3; python_version == "3.8"
+onnxruntime>=1.14,<2
 av>=11
 tqdm


### PR DESCRIPTION
since support for python 3.8 was removed in version 0.21.0 of tokenizers, this constraints it to the latest supported version