### PR TITLE
change language_detection_threshold type to float

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -731,7 +731,7 @@ class WhisperModel:
         clip_timestamps: Union[str, List[float]] = "0",
         hallucination_silence_threshold: Optional[float] = None,
         hotwords: Optional[str] = None,
-        language_detection_threshold: Optional[float] = 0.5,
+        language_detection_threshold: float = 0.5,
         language_detection_segments: int = 1,
     ) -> Tuple[Iterable[Segment], TranscriptionInfo]:
         """Transcribes an input file.

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -2,6 +2,7 @@ import inspect
 import os
 
 import numpy as np
+import pytest
 
 from faster_whisper import BatchedInferencePipeline, WhisperModel, decode_audio
 
@@ -269,3 +270,9 @@ def test_monotonic_timestamps(physcisworks_path):
             assert word.start <= word.end
             assert word.end <= segments[i].end
     assert segments[-1].end <= info.duration
+
+
+def test_language_detection_threshold_none_raises_error(jfk_path):
+    model = WhisperModel("tiny")
+    with pytest.raises(TypeError):
+        model.transcribe(jfk_path, language_detection_threshold=None)  # type: ignore


### PR DESCRIPTION
`language_detection_threshold` can't be supplied as `None` as `detect_language` compares it with a `float`.

Change parameter type in `WhisperModel` to reflect this.

Added test to confirm this behavior.