### PR TITLE
fix the xxx.cudnn.so.8 missing error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,11 @@
-FROM nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04
+FROM nvidia/cuda:12.2.2-cudnn8-devel-ubuntu20.04
+
 WORKDIR /root
+
 RUN apt-get update -y && apt-get install -y python3-pip
-COPY infer.py jfk.flac ./
-RUN pip3 install faster-whisper
+
+COPY requirements.txt infer.py jfk.flac ./
+
+RUN pip3 install -r requirements.txt
+
 CMD ["python3", "infer.py"]

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,8 @@
+faster-whisper==1.0.1
+ctranslate2==4.0
+huggingface_hub==0.26.3
+tokenizers==0.13.1
+onnxruntime==1.14 
+av==11
+flask==3.0.1
+numpy==1.24.4


### PR DESCRIPTION
The base image  and requirements  were done well and tested!

docker exec -ti d7d592e84c1e /bin/bash
root@d7d592e84c1e:/app# nvidia-smi
Fri Dec  6 02:18:38 2024       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 555.42.06              Driver Version: 555.42.06      CUDA Version: 12.5     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 3070        Off |   00000000:03:00.0 Off |                  N/A |
|  0%   35C    P8             17W /  240W |     350MiB /   8192MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
+-----------------------------------------------------------------------------------------+

Note that the host has cuda 12.5 and the  container has cudnn 8 files