### PR TITLE
Fixes OOM Errors - too high RAM usage by VAD

### DIFF
--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -302,7 +302,15 @@ class SileroVADModel:
 
         batched_audio = batched_audio.reshape(-1, num_samples + context_size_samples)
 
-        encoder_output = self.encoder_session.run(None, {"input": batched_audio})[0]
+        batch_process_size = 10000
+        num_segments = batched_audio.shape[0]
+        encoder_outputs = []
+        for start in range(0, num_segments, batch_process_size):
+            end = min(start + batch_process_size, num_segments)
+            encoder_output = self.encoder_session.run(None, {"input": batched_audio[start:end]})[0]
+            encoder_outputs.append(encoder_output)
+
+        encoder_output = np.concatenate(encoder_outputs, axis=0)
         encoder_output = encoder_output.reshape(batch_size, -1, 128)
 
         decoder_outputs = []

--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -307,7 +307,9 @@ class SileroVADModel:
         encoder_outputs = []
         for start in range(0, num_segments, batch_process_size):
             end = min(start + batch_process_size, num_segments)
-            encoder_output = self.encoder_session.run(None, {"input": batched_audio[start:end]})[0]
+            encoder_output = self.encoder_session.run(
+                None, {"input": batched_audio[start:end]}
+            )[0]
             encoder_outputs.append(encoder_output)
 
         encoder_output = np.concatenate(encoder_outputs, axis=0)

--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -302,13 +302,12 @@ class SileroVADModel:
 
         batched_audio = batched_audio.reshape(-1, num_samples + context_size_samples)
 
-        batch_process_size = 10000
+        encoder_batch_size = 10000
         num_segments = batched_audio.shape[0]
         encoder_outputs = []
-        for start in range(0, num_segments, batch_process_size):
-            end = min(start + batch_process_size, num_segments)
+        for i in range(0, num_segments, encoder_batch_size):
             encoder_output = self.encoder_session.run(
-                None, {"input": batched_audio[start:end]}
+                None, {"input": batched_audio[i : i + encoder_batch_size]}
             )[0]
             encoder_outputs.append(encoder_output)
 

--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -260,8 +260,9 @@ class SileroVADModel:
             ) from e
 
         opts = onnxruntime.SessionOptions()
-        opts.inter_op_num_threads = 0
-        opts.intra_op_num_threads = 0
+        opts.inter_op_num_threads = 1
+        opts.intra_op_num_threads = 1
+        opts.enable_cpu_mem_arena = False
         opts.log_severity_level = 4
 
         self.encoder_session = onnxruntime.InferenceSession(


### PR DESCRIPTION
fixes #1193 and #1169 
VAD implementation consumes humongous memory amount [original Silero doesn't have this problem]

This PR should fix the OOM problem.
Alt solution could be removing `lru_cache`.