### PR TITLE
Update cudnn semantic version in README to avoid performance issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The libraries (cuBLAS, cuDNN) are installed in this official NVIDIA CUDA Docker 
 On Linux these libraries can be installed with `pip`. Note that `LD_LIBRARY_PATH` must be set before launching Python.
 
 ```bash
-pip install nvidia-cublas-cu12 nvidia-cudnn-cu12==9.*
+pip install nvidia-cublas-cu12 'nvidia-cudnn-cu12<9.6,>=9'
 
 export LD_LIBRARY_PATH=`python3 -c 'import os; import nvidia.cublas.lib; import nvidia.cudnn.lib; print(os.path.dirname(nvidia.cublas.lib.__file__) + ":" + os.path.dirname(nvidia.cudnn.lib.__file__))'`
 ```


### PR DESCRIPTION
I suggest changing the version spec of `nvidia-cublas-cu12` and `nvidia-cudnn-cu12`. Using existing one:

```bash
pip install nvidia-cublas-cu12 nvidia-cudnn-cu12==9.*
```

on 2025-02-07 gives

```
nvidia-cublas-cu12==12.8.3.14
nvidia-cudnn-cu12==9.7.1.26
```

which results in cuda running 30x slower than cpu on my Ubuntu 22.04, with a 6 seconds wav audio.

After I downgrade them to:

```
nvidia-cublas-cu12==12.4.5.8
nvidia-cudnn-cu12==9.1.0.70
```

which is what `torch==2.6.0` currently depends on, everything works fine. Then, I go through a thorough grid search over recent cublas and cudnn versions, and find that all cudnn after 9.6 (inclusive) exhibit the aforementioned performance issue.

I didn't study the lower bound, though. Hence, I make it compatible with current semantic version, i.e. `>=9`).

That's why I make this change.

Thank you so much!