### PR TITLE
Decouple onnxruntime cpu and gpu requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install module
         run: |
           pip install wheel
-          pip install -e .[dev]
+          pip install -e .[dev,cpu]
 
       - name: Check code format with Black
         run: |
@@ -55,7 +55,7 @@ jobs:
       - name: Install module
         run: |
           pip install wheel
-          pip install -e .[dev]
+          pip install -e .[dev,cpu]
 
       - name: Run pytest
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We recommend installing the module in editable mode with the `dev` extra require
 ```bash
 git clone https://github.com/SYSTRAN/faster-whisper.git
 cd faster-whisper/
-pip install -e .[dev]
+pip install -e .[dev,cpu]
 ```
 
 ## Validate the changes before creating a pull request

--- a/README.md
+++ b/README.md
@@ -102,8 +102,14 @@ Purfview's [whisper-standalone-win](https://github.com/Purfview/whisper-standalo
 The module can be installed from [PyPI](https://pypi.org/project/faster-whisper/):
 
 ```bash
-pip install faster-whisper
+# Install with CPU support (default)
+pip install faster-whisper[cpu]
+
+# Install with GPU support
+pip install faster-whisper[gpu]
 ```
+
+Note: Installing just `pip install faster-whisper` will not include any onnxruntime backend. You must explicitly choose either the CPU or GPU version.
 
 <details>
 <summary>Other installation methods (click to expand)</summary>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,5 +2,5 @@ FROM nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04
 WORKDIR /root
 RUN apt-get update -y && apt-get install -y python3-pip
 COPY infer.py jfk.flac ./
-RUN pip3 install faster-whisper
+RUN pip3 install faster-whisper[cpu]
 CMD ["python3", "infer.py"]

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,0 +1,1 @@
+onnxruntime>=1.14,<2 

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,0 +1,1 @@
+onnxruntime-gpu>=1.14,<2 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 ctranslate2>=4.0,<5
 huggingface_hub>=0.13
 tokenizers>=0.13,<1
-onnxruntime>=1.14,<2 
 av>=11
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ def get_requirements(path):
 
 
 install_requires = get_requirements(os.path.join(base_dir, "requirements.txt"))
+cpu_requires = get_requirements(os.path.join(base_dir, "requirements-cpu.txt"))
+gpu_requires = get_requirements(os.path.join(base_dir, "requirements-gpu.txt"))
 conversion_requires = get_requirements(
     os.path.join(base_dir, "requirements.conversion.txt")
 )
@@ -52,9 +54,11 @@ setup(
     ],
     keywords="openai whisper speech ctranslate2 inference quantization transformer",
     python_requires=">=3.9",
-    install_requires=install_requires,
+    install_requires=install_requires,  # Base requirements only
     extras_require={
         "conversion": conversion_requires,
+        "cpu": cpu_requires,
+        "gpu": gpu_requires,
         "dev": [
             "black==23.*",
             "flake8==6.*",


### PR DESCRIPTION
This has been discussed before in https://github.com/microsoft/onnxruntime/issues/7313 and https://github.com/SYSTRAN/faster-whisper/pull/499

#### Problem description

- Let's package `xyz` (meant to be GPU accelerated) depends on faster-whisper
- `xyz` explicitly lists onnxruntime-gpu in their dependencies
- `xyz` uses a package manager with a lockfile setup (like `poetry` or `uv`)
- Installing package `xyz` ends up installing both `onnxruntime` and `onnxruntime-gpu` in its environment

This is undesirable (https://github.com/SYSTRAN/faster-whisper/issues/364#issuecomment-1645272083) , and requires `onnxruntime` to be manually removed, and `onnxruntime-gpu` to manually be reinstalled. 

#### Proposed solution

- Break out the CPU and GPU requirements as explicit extras. This is a **breaking change**
- `pip install faster-whisper` will **not** install onnxruntime in anyflavour.
- Instead, one will have to `pip install faster-whisper[cpu]` or `pip install faster-whisper[gpu]` 


Happy to modify and iterate on this PR as much as required, but due to onnxruntime's weird behaviour (onnxruntime-gpu incompatible with onnxruntime), this is causing many downstream projects to "invent" their own way of dealing with non-standard installs