### PR TITLE
Remove Silence in Batched transcription

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -25,7 +25,6 @@ from faster_whisper.vad import (
     VadOptions,
     collect_chunks,
     get_speech_timestamps,
-    merge_segments,
 )
 
 
@@ -125,7 +124,7 @@ class BatchedInferencePipeline:
         segmented_outputs = []
         segment_sizes = []
         for chunk_metadata, output in zip(chunks_metadata, outputs):
-            duration = chunk_metadata["end_time"] - chunk_metadata["start_time"]
+            duration = chunk_metadata["duration"]
             segment_size = int(ceil(duration) * self.model.frames_per_second)
             segment_sizes.append(segment_size)
             (
@@ -135,7 +134,7 @@ class BatchedInferencePipeline:
             ) = self.model._split_segments_by_timestamps(
                 tokenizer=tokenizer,
                 tokens=output["tokens"],
-                time_offset=chunk_metadata["start_time"],
+                time_offset=chunk_metadata["offset"],
                 segment_size=segment_size,
                 segment_duration=duration,
                 seek=0,
@@ -153,7 +152,7 @@ class BatchedInferencePipeline:
                             tokenizer.decode(subsegment["tokens"])
                         ),
                         seek=int(
-                            chunk_metadata["start_time"] * self.model.frames_per_second
+                            chunk_metadata["offset"] * self.model.frames_per_second
                         ),
                     )
                     for subsegment in subsegments
@@ -409,8 +408,7 @@ class BatchedInferencePipeline:
                         **vad_parameters, max_speech_duration_s=chunk_length
                     )
 
-                active_segments = get_speech_timestamps(audio, vad_parameters)
-                clip_timestamps = merge_segments(active_segments, vad_parameters)
+                clip_timestamps = get_speech_timestamps(audio, vad_parameters)
             # run the audio if it is less than 30 sec even without clip_timestamps
             elif duration < chunk_length:
                 clip_timestamps = [{"start": 0, "end": audio.shape[0]}]
@@ -419,6 +417,15 @@ class BatchedInferencePipeline:
                     "No clip timestamps found. "
                     "Set 'vad_filter' to True or provide 'clip_timestamps'."
                 )
+        else:
+            clip_timestamps = [
+                {k: int(v * sampling_rate) for k, v in segment.items()}
+                for segment in clip_timestamps
+            ]
+
+        audio_chunks, chunks_metadata = collect_chunks(
+            audio, clip_timestamps, max_duration=chunk_length
+        )
 
         duration_after_vad = (
             sum((segment["end"] - segment["start"]) for segment in clip_timestamps)
@@ -430,7 +437,6 @@ class BatchedInferencePipeline:
             format_timestamp(duration - duration_after_vad),
         )
 
-        audio_chunks, chunks_metadata = collect_chunks(audio, clip_timestamps)
         features = (
             [self.model.feature_extractor(chunk)[..., :-1] for chunk in audio_chunks]
             if duration_after_vad
@@ -541,6 +547,7 @@ class BatchedInferencePipeline:
             options,
             log_progress,
         )
+        segments = restore_speech_timestamps(segments, clip_timestamps, sampling_rate)
 
         return segments, info
 

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -71,7 +71,7 @@ def test_batched_transcribe(physcisworks_path):
             {"start": segment.start, "end": segment.end, "text": segment.text}
         )
     # number of near 30 sec segments
-    assert len(segments) == 7
+    assert len(segments) == 6
 
     result, info = batched_model.transcribe(
         physcisworks_path,


### PR DESCRIPTION
The current VAD implementation in batched transcription is only used for segmentation, silence is only removed at segments boundaries, for example, if we have a speech segment from 1 to 3 and another from 9 to 10, the resulting segment will be from 1 to 10, including a large silence period from 3 to 9 which is prone to hallucinations

This PR concatenates speech only until the desirable chunk size is reached and ignoring the silence in-between thus reducing hallucinations in batched mode
Since the speech is condensed, more words per segment should be expected in the transcript, potential slight speedup is also expected due to less segments for long files

Results after increasing `min_silence_duration_ms` to 800:
| Model               | Before WER | After WER  |
|---------------------|------------|------------|
| tiny.en             | **15.063** | 15.088     |
| tiny                | **21.390** | 22.112     |
| base.en             | 13.816 | **13.597**     |
| base                | 17.251 | **16.735**     |
| small.en            | **12.617**     | 12.649 |
| small               | 16.088 | **16.050**    |
| medium.en           | 12.894     | **12.786** |
| medium              | 15.593 | **15.218**     |
| large-v1            | 19.590     | **16.121** |
| large-v2            | 15.148     | **14.103** |
| large-v3            | 15.997     | **15.549** |
| large-v3-turbo      | 14.044     | **13.561** |
| distil-small.en     | 13.918     | **13.784** |
| distil-medium.en    | 13.972 | **13.916**     |
| distil-large-v2     | **13.574** | 13.595     |
| distil-large-v3     | 13.533     | **13.512** |


These figures can be reproduced by running `benchmarks/yt_commons.py`

