### PR TITLE
Do not encode supplied `initial_prompt` if it is not a string

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -316,8 +316,7 @@ class BatchedInferencePipeline:
             no_repeat_ngram_size: Prevent repetitions of ngrams with this size (set 0 to disable).
             temperature: Temperature for sampling. If a list or tuple is passed,
                 only the first value is used.
-            initial_prompt: Optional text string to provide as a
-                prompt for each window.
+            initial_prompt: Optional text string to provide as a prompt for each window.
             suppress_blank: Suppress blank outputs at the beginning of the sampling.
             suppress_tokens: List of token IDs to suppress. -1 will suppress a default set
                 of symbols as defined in `tokenizer.non_speech_tokens()`.


### PR DESCRIPTION
The `BatchedInferencePipeline#transcribe` method [technically supports](https://github.com/SYSTRAN/faster-whisper/blob/700584b2e6c15825c73e232f323e4b910257fa1c/faster_whisper/transcribe.py#L280) passing an already encoded tokenized list as the `initial_prompt`. The code path should only try to encode the provided prompt if it's a string.

This fixes the bug where faster_whisper will fail due to: `TypeError: TextInputSequence must be str` when passing a List of integers as the `initial_prompt`.