### PR TITLE
Make prefix work for batched inference

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -189,6 +189,7 @@ class BatchedInferencePipeline:
             ),
             without_timestamps=options.without_timestamps,
             hotwords=options.hotwords,
+            prefix=options.prefix,
         )
 
         if options.max_new_tokens is not None:


### PR DESCRIPTION
Prefix is ignored during batched inference, resulting in a different behavior than when running faster whisper without batched inference. This PR aims to be a simple fix for that.