### PR TITLE
Fix typo in multilingual test

### DIFF
--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -190,7 +190,7 @@ def test_multilingual_transcription(data_dir):
         "verfahren. Dies umfasst insbesondere das Recht, die Software zu verwenden, zu "
         "vervielfältigen, zu modifizieren, zu Samenzofügen, zu veröffentlichen, zu verteilen, "
         "unterzulizenzieren und oder kopieren der Software zu verkaufen und diese Rechte "
-        "unterfolgen den Bedingungen anderen zu übertragen."
+        "unterfolgenden den Bedingungen anderen zu übertragen."
     )
 
     segments, info = pipeline.transcribe(audio, multilingual=True)

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -190,7 +190,7 @@ def test_multilingual_transcription(data_dir):
         "verfahren. Dies umfasst insbesondere das Recht, die Software zu verwenden, zu "
         "vervielfältigen, zu modifizieren, zu Samenzofügen, zu veröffentlichen, zu verteilen, "
         "unterzulizenzieren und oder kopieren der Software zu verkaufen und diese Rechte "
-        "unterfolgenden den Bedingungen anderen zu übertragen."
+        "unterfolgenden Bedingungen anderen zu übertragen."
     )
 
     segments, info = pipeline.transcribe(audio, multilingual=True)


### PR DESCRIPTION
Fixes a typo in the German transcription of the multilingual test.

https://github.com/SYSTRAN/faster-whisper/issues/1348


I don't know German so I asked an LLM: 

The second option, **"unter folgenden Bedingungen anderen zu übertragen"**, is the most correct.

Here's a breakdown of why:

* **"Unter"** is a two-way preposition in German, meaning it can take either the dative or accusative case. In this context, where it means "under" or "subject to" certain conditions, it requires the **dative case**.
* **"Bedingungen"** is a plural noun.
* The adjective **"folgend"** (following) comes before the noun and must therefore be declined according to the dative plural case.

The correct dative plural declension for an adjective like "folgend" is to add an **-en** ending. Therefore, "folgenden" is the grammatically correct form.

The first option, "unter folgen den Bedingungen," incorrectly separates the adjective ending and uses an incorrect declension.