### PR TITLE
Adds new VAD parameters + some VAD tweaks

### DIFF
--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -40,7 +40,7 @@ class VadOptions:
 
     threshold: float = 0.5
     neg_threshold: float = None
-    min_speech_duration_ms: int = 250
+    min_speech_duration_ms: int = 0
     max_speech_duration_s: float = float("inf")
     min_silence_duration_ms: int = 2000
     speech_pad_ms: int = 400


### PR DESCRIPTION
Adds new VAD parameters: 

min_silence_at_max_speech: Minimum silence duration in ms which is used to avoid abrupt cuts when max_speech_duration_s is reached.

use_max_poss_sil_at_max_speech: Whether to use the maximum possible silence at max_speech_duration_s or not. If not, the last silence is used.

"min_silence_at_max_speech" previously was hardcoded = 98 ms
"use_max_poss_sil_at_max_speech" helps to avoid abrupt cuts

Relevant links:
https://github.com/snakers4/silero-vad/pull/664
https://github.com/snakers4/silero-vad/pull/710