### PR TITLE
Bugfix: Fix inconsistent VAD defaults in BatchedInferencePipeline

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -395,18 +395,16 @@ class BatchedInferencePipeline:
         # if no segment split is provided, use vad_model and generate segments
         if not clip_timestamps:
             if vad_filter:
+                batched_class_defaults = VadOptions(
+                    max_speech_duration_s=chunk_length,
+                    min_silence_duration_ms=160,
+                )
                 if vad_parameters is None:
-                    vad_parameters = VadOptions(
-                        max_speech_duration_s=chunk_length,
-                        min_silence_duration_ms=160,
-                    )
+                    vad_parameters = batched_class_defaults
                 elif isinstance(vad_parameters, dict):
-                    if "max_speech_duration_s" in vad_parameters.keys():
-                        vad_parameters.pop("max_speech_duration_s")
-
-                    vad_parameters = VadOptions(
-                        **vad_parameters, max_speech_duration_s=chunk_length
-                    )
+                    merged_vad_params = {**asdict(batched_class_defaults), **vad_parameters}
+                    merged_vad_params["max_speech_duration_s"] = chunk_length
+                    vad_parameters = VadOptions(**merged_vad_params)
 
                 clip_timestamps = get_speech_timestamps(audio, vad_parameters)
             # run the audio if it is less than 30 sec even without clip_timestamps

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -395,14 +395,14 @@ class BatchedInferencePipeline:
         # if no segment split is provided, use vad_model and generate segments
         if not clip_timestamps:
             if vad_filter:
-                batched_class_defaults = VadOptions(
+                batched_defaults = VadOptions(
                     max_speech_duration_s=chunk_length,
                     min_silence_duration_ms=160,
                 )
                 if vad_parameters is None:
-                    vad_parameters = batched_class_defaults
+                    vad_parameters = batched_defaults
                 elif isinstance(vad_parameters, dict):
-                    merged_vad_params = {**asdict(batched_class_defaults), **vad_parameters}
+                    merged_vad_params = {**asdict(batched_defaults), **vad_parameters}
                     merged_vad_params["max_speech_duration_s"] = chunk_length
                     vad_parameters = VadOptions(**merged_vad_params)
 

--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -42,7 +42,7 @@ class VadOptions:
     neg_threshold: float = None
     min_speech_duration_ms: int = 0
     max_speech_duration_s: float = float("inf")
-    min_silence_duration_ms: int = 2000  # Note: defaults to 160 in BatchedInferencePipeline
+    min_silence_duration_ms: int = 2000  # defaults to 160 in BatchedInferencePipeline
     speech_pad_ms: int = 400
     min_silence_at_max_speech: int = 98
     use_max_poss_sil_at_max_speech: bool = True

--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -42,7 +42,7 @@ class VadOptions:
     neg_threshold: float = None
     min_speech_duration_ms: int = 0
     max_speech_duration_s: float = float("inf")
-    min_silence_duration_ms: int = 2000  # Note: defaults to 160 in BatchedInferencePipeline 
+    min_silence_duration_ms: int = 2000  # Note: defaults to 160 in BatchedInferencePipeline
     speech_pad_ms: int = 400
     min_silence_at_max_speech: int = 98
     use_max_poss_sil_at_max_speech: bool = True

--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -42,7 +42,7 @@ class VadOptions:
     neg_threshold: float = None
     min_speech_duration_ms: int = 0
     max_speech_duration_s: float = float("inf")
-    min_silence_duration_ms: int = 2000
+    min_silence_duration_ms: int = 2000  # Note: defaults to 160 in BatchedInferencePipeline 
     speech_pad_ms: int = 400
     min_silence_at_max_speech: int = 98
     use_max_poss_sil_at_max_speech: bool = True


### PR DESCRIPTION
Fixes inconsistent VAD defaults in BatchedInferencePipeline

Bug:
BatchedInferencePipeline applies inconsistent defaults for `min_silence_duration_ms`.
If `vad_parameters` is not passed, the value defaults to `160`. When e.g. only `threshold` is passed, it defaults to `2000`.