### PR TITLE
Fix VAD tie-break to prefer latest max-silence candidate

### DIFF
--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -128,7 +128,7 @@ def get_speech_timestamps(
 
         if triggered and (cur_sample - current_speech["start"] > max_speech_samples):
             if use_max_poss_sil_at_max_speech and possible_ends:
-                prev_end, dur = max(possible_ends, key=lambda x: x[1])
+                prev_end, dur = max(possible_ends, key=lambda x: (x[1], x[0]))
                 current_speech["end"] = prev_end
                 speeches.append(current_speech)
                 current_speech = {}

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+import faster_whisper.vad as vad
+
+
+def test_get_speech_timestamps_prefers_latest_silence_on_tie(monkeypatch):
+    # Two equal-length silence candidates appear before max_speech is exceeded.
+    speech_probs = np.array(
+        [0.9] * 90 + [0.05] * 13 + [0.9] * 20 + [0.05] * 13 + [0.9] * 100,
+        dtype=np.float32,
+    )
+    monkeypatch.setattr(vad, "get_vad_model", lambda: (lambda audio: speech_probs))
+
+    audio = np.zeros(len(speech_probs) * 512, dtype=np.float32)
+    speeches = vad.get_speech_timestamps(
+        audio,
+        vad_options=vad.VadOptions(
+            threshold=0.5,
+            neg_threshold=0.35,
+            min_speech_duration_ms=0,
+            max_speech_duration_s=4.6,
+            min_silence_duration_ms=2000,
+            speech_pad_ms=0,
+            min_silence_at_max_speech=98,
+            use_max_poss_sil_at_max_speech=True,
+        ),
+        sampling_rate=16000,
+    )
+
+    # Tie on silence length should pick the most recent candidate.
+    assert speeches[0]["end"] == (90 + 13 + 20) * 512


### PR DESCRIPTION
## Summary
When `use_max_poss_sil_at_max_speech=True`, `get_speech_timestamps` currently picks the first candidate when multiple silence candidates have the same duration.

## Problem
`max(possible_ends, key=lambda x: x[1])` breaks ties by first occurrence, which biases the split point toward older silence segments instead of the most recent one near the max-speech boundary.

## Fix
Use recency as a tie-breaker:
- from: `key=lambda x: x[1]`
- to: `key=lambda x: (x[1], x[0])`

This preserves the longest-silence behavior and, on ties, chooses the latest candidate.

## Tests
Added `tests/test_vad.py`:
- `test_get_speech_timestamps_prefers_latest_silence_on_tie`

Ran:
- `pytest -q tests/test_vad.py` (Passed)
