### PR TITLE
Fix merge_punctuations for multi-char words with apostrophes

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -1914,7 +1914,9 @@ def merge_punctuations(alignment: List[dict], prepended: str, appended: str) -> 
     while i >= 0:
         previous = alignment[i]
         following = alignment[j]
-        if previous["word"].startswith(" ") and previous["word"].strip() in prepended:
+        if previous["word"].startswith(" ") and any(
+            previous["word"].strip().endswith(p) for p in prepended
+        ):
             # prepend it to the following word
             following["word"] = previous["word"] + following["word"]
             following["tokens"] = previous["tokens"] + following["tokens"]
@@ -1930,7 +1932,9 @@ def merge_punctuations(alignment: List[dict], prepended: str, appended: str) -> 
     while j < len(alignment):
         previous = alignment[i]
         following = alignment[j]
-        if not previous["word"].endswith(" ") and following["word"] in appended:
+        if not previous["word"].endswith(" ") and any(
+            following["word"].startswith(p) for p in appended
+        ):
             # append it to the previous word
             previous["word"] = previous["word"] + following["word"]
             previous["tokens"] = previous["tokens"] + following["tokens"]

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 
 from faster_whisper import BatchedInferencePipeline, WhisperModel, decode_audio
+from faster_whisper.transcribe import merge_punctuations
 
 
 def test_supported_languages():
@@ -313,3 +314,39 @@ def test_cliptimestamps_timings(physcisworks_path):
         assert clip["start"] == segment.start
         assert clip["end"] == segment.end
         assert segment.text == transcript
+
+
+def test_merge_punctuations_french_apostrophe():
+    """Test that words ending with apostrophe (e.g. French j', l') are merged."""
+    prepended = "\"'\u2018\u2019\u00bf([{-"
+    appended = "\"'.\u3002,\uff0c!\uff01?\uff1f:\uff1a\u201c\u201d)]\u007d\u3001"
+
+    alignment = [
+        {"word": " Bonjour", "tokens": [1]},
+        {"word": " j'", "tokens": [2]},
+        {"word": "ai", "tokens": [3]},
+        {"word": " l'", "tokens": [4]},
+        {"word": "avion", "tokens": [5]},
+    ]
+
+    merge_punctuations(alignment, prepended, appended)
+
+    words = [w["word"] for w in alignment if w["word"]]
+    assert words == [" Bonjour", " j'ai", " l'avion"]
+
+
+def test_merge_punctuations_single_char():
+    """Test that single-character punctuation still merges correctly."""
+    prepended = "\"'\u2018\u2019\u00bf([{-"
+    appended = "\"'.,!?:)]\u007d\u3001"
+
+    alignment = [
+        {"word": ' "', "tokens": [1]},
+        {"word": "hello", "tokens": [2]},
+        {"word": ".", "tokens": [3]},
+    ]
+
+    merge_punctuations(alignment, prepended, appended)
+
+    words = [w["word"] for w in alignment if w["word"]]
+    assert words == [' "hello.']


### PR DESCRIPTION
## Problem

`merge_punctuations` fails to merge words that end with a prepend punctuation character but are multi-character (e.g., French `j'`, `l'`). This causes word timestamps to incorrectly split these words.

## Root Cause

The check `previous["word"].strip() in prepended` tests whether the entire stripped word is a single character in the punctuation string. Multi-character words like `j'` fail this check.

## Fix

- Prepended: check if word **ends with** any punctuation char
- Appended: check if word **starts with** any punctuation char

## Tests

Added `test_merge_punctuations_french_apostrophe` and `test_merge_punctuations_single_char`.

Fixes #1252