### PR TITLE
ci: pin GitHub Actions and set least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,19 @@ on:
     branches:
       - master
 
+# Least privilege: this workflow only needs to read repository contents.
+permissions:
+  contents: read
+
 jobs:
   check-code-format:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.9
 
@@ -45,10 +49,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.9
 
@@ -67,10 +71,10 @@ jobs:
     needs: [check-code-format, run-tests]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.9
 
@@ -84,7 +88,7 @@ jobs:
 
       - name: Push package on PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### What
Harden `.github/workflows/ci.yml` without changing behavior:
- Add least-privilege `permissions: contents: read`.
- Pin `actions/checkout`, `actions/setup-python`, and `pypa/gh-action-pypi-publish` to full commit SHAs.

### Why
Using tag-based action refs (e.g. `@v4`, `@v5`, `@release/v1`) increases supply-chain risk if a tag is moved or compromised.

### Testing
- YAML parsed locally (PyYAML `yaml.safe_load`).
