### PR TITLE
fix: pin ctranslate2<4.6.3 to maintain CUDA compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ctranslate2>=4.0,<5
+ctranslate2>=4.0,<4.6.3
 huggingface_hub>=0.23
 tokenizers>=0.13,<1
 onnxruntime>=1.14,<2 


### PR DESCRIPTION
## Problem

ctranslate2 4.6.3 dropped support for CUDA devices below 12.8 (OpenNMT/CTranslate2#1978). Since faster-whisper specifies `ctranslate2>=4.0,<5`, users on older CUDA versions get broken installations when pip resolves to 4.6.3+.

## Fix

Pin `ctranslate2>=4.0,<4.6.3` in `requirements.txt` to maintain backward compatibility.

Fixes #1413