### PR TITLE
Add audio_backend parameter (pyav default, ffmpeg alternative)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ For reference, here's the time and memory usage that are required to transcribe 
 
 Unlike openai-whisper, FFmpeg does **not** need to be installed on the system. The audio is decoded with the Python library [PyAV](https://github.com/PyAV-Org/PyAV) which bundles the FFmpeg libraries in its package.
 
+If PyAV cannot be loaded in your environment (for example on Windows 11 with Smart App Control enabled, which blocks unsigned DLLs shipped by the PyAV wheel), you can opt into the alternative `ffmpeg` audio backend, which shells out to a system `ffmpeg` binary instead:
+
+```python
+model = WhisperModel("large-v3", audio_backend="ffmpeg")
+```
+
+This requires `ffmpeg` to be available on `PATH`, or the `FFMPEG_EXE` environment variable to point at its absolute path. The default remains `audio_backend="pyav"`, so nothing changes for existing users.
+
 ### GPU
 
 GPU execution requires the following NVIDIA libraries to be installed:

--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -1,25 +1,37 @@
-"""We use the PyAV library to decode the audio: https://github.com/PyAV-Org/PyAV
+"""Audio decoding with pluggable backends.
 
-The advantage of PyAV is that it bundles the FFmpeg libraries so there is no additional
-system dependencies. FFmpeg does not need to be installed on the system.
+By default, audio is decoded via the Python library `PyAV`
+(https://github.com/PyAV-Org/PyAV), which bundles FFmpeg so no system
+dependency is required.
 
-However, the API is quite low-level so we need to manipulate audio frames directly.
+An alternative `ffmpeg` backend is also available. It shells out to the
+`ffmpeg` binary via `subprocess`. This is useful on environments where the
+PyAV wheels cannot be loaded (e.g. Windows 11 Smart App Control blocking
+unsigned binaries, locked-down corporate environments, or sandboxes that
+forbid loading arbitrary DLLs) but where a signed/system `ffmpeg` binary is
+available on PATH. Select it via the `audio_backend='ffmpeg'` parameter on
+`WhisperModel` (or by calling `decode_audio(..., backend='ffmpeg')`).
 """
 
 import gc
 import io
 import itertools
+import os
+import shutil
+import subprocess
 
-from typing import BinaryIO, Union
+from typing import BinaryIO, Optional, Union
 
-import av
 import numpy as np
+
+SUPPORTED_AUDIO_BACKENDS = ("pyav", "ffmpeg")
 
 
 def decode_audio(
     input_file: Union[str, BinaryIO],
     sampling_rate: int = 16000,
     split_stereo: bool = False,
+    backend: str = "pyav",
 ):
     """Decodes the audio.
 
@@ -27,13 +39,54 @@ def decode_audio(
       input_file: Path to the input file or a file-like object.
       sampling_rate: Resample the audio to this sample rate.
       split_stereo: Return separate left and right channels.
+      backend: Which decoding backend to use. One of:
+        - "pyav" (default): decode in-process using the PyAV library.
+        - "ffmpeg": shell out to the `ffmpeg` binary via subprocess.
+          Requires `ffmpeg` to be available on PATH (or set the
+          `FFMPEG_EXE` environment variable to the absolute path of the
+          executable).
 
     Returns:
       A float32 Numpy array.
 
       If `split_stereo` is enabled, the function returns a 2-tuple with the
       separated left and right channels.
+
+    Raises:
+      ValueError: if `backend` is not one of the supported backends.
+      RuntimeError: if `backend='ffmpeg'` and the `ffmpeg` binary cannot be
+        located, or decoding fails.
     """
+    if backend not in SUPPORTED_AUDIO_BACKENDS:
+        raise ValueError(
+            f"Unsupported audio_backend={backend!r}. "
+            f"Expected one of {SUPPORTED_AUDIO_BACKENDS}."
+        )
+
+    if backend == "ffmpeg":
+        return _decode_audio_ffmpeg(
+            input_file,
+            sampling_rate=sampling_rate,
+            split_stereo=split_stereo,
+        )
+
+    return _decode_audio_pyav(
+        input_file,
+        sampling_rate=sampling_rate,
+        split_stereo=split_stereo,
+    )
+
+
+def _decode_audio_pyav(
+    input_file: Union[str, BinaryIO],
+    sampling_rate: int = 16000,
+    split_stereo: bool = False,
+):
+    # Import PyAV lazily so environments that cannot load its DLLs/shared
+    # libraries (e.g. Windows 11 Smart App Control) can still use the
+    # ffmpeg backend without ever triggering an `import av`.
+    import av
+
     resampler = av.audio.resampler.AudioResampler(
         format="s16",
         layout="mono" if not split_stereo else "stereo",
@@ -76,7 +129,79 @@ def decode_audio(
     return audio
 
 
+def _find_ffmpeg_executable() -> str:
+    """Locate the ffmpeg binary. Honors FFMPEG_EXE env var first."""
+    env = os.environ.get("FFMPEG_EXE")
+    if env and os.path.isfile(env):
+        return env
+    found = shutil.which("ffmpeg")
+    if found:
+        return found
+    raise RuntimeError(
+        "audio_backend='ffmpeg' requires the ffmpeg binary to be available "
+        "on PATH (or set the FFMPEG_EXE environment variable to its absolute "
+        "path). Install ffmpeg from https://ffmpeg.org/download.html."
+    )
+
+
+def _decode_audio_ffmpeg(
+    input_file: Union[str, BinaryIO],
+    sampling_rate: int = 16000,
+    split_stereo: bool = False,
+):
+    ffmpeg = _find_ffmpeg_executable()
+
+    channels = 2 if split_stereo else 1
+    is_path = isinstance(input_file, (str, bytes, os.PathLike))
+
+    cmd = [
+        ffmpeg,
+        "-nostdin",
+        "-threads", "0",
+        "-i", str(input_file) if is_path else "-",
+        "-f", "s16le",
+        "-ac", str(channels),
+        "-acodec", "pcm_s16le",
+        "-ar", str(sampling_rate),
+        "-loglevel", "error",
+        "-",
+    ]
+
+    stdin_data: Optional[bytes] = None
+    if not is_path:
+        if hasattr(input_file, "seek"):
+            try:
+                input_file.seek(0)
+            except Exception:
+                pass
+        stdin_data = input_file.read()
+
+    try:
+        completed = subprocess.run(
+            cmd,
+            input=stdin_data,
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"ffmpeg decode failed (exit {exc.returncode}): "
+            f"{exc.stderr.decode('utf-8', errors='replace')}"
+        ) from exc
+
+    audio = np.frombuffer(completed.stdout, dtype=np.int16).astype(np.float32) / 32768.0
+
+    if split_stereo:
+        left = audio[0::2]
+        right = audio[1::2]
+        return left, right
+
+    return audio
+
+
 def _ignore_invalid_frames(frames):
+    import av  # noqa: WPS433 (mirror import location of _decode_audio_pyav)
+
     iterator = iter(frames)
 
     while True:
@@ -89,6 +214,8 @@ def _ignore_invalid_frames(frames):
 
 
 def _group_frames(frames, num_samples=None):
+    import av  # noqa: WPS433 (PyAV only needed inside the pyav backend)
+
     fifo = av.audio.fifo.AudioFifo()
 
     for frame in frames:

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -16,7 +16,7 @@ import tokenizers
 
 from tqdm import tqdm
 
-from faster_whisper.audio import decode_audio, pad_or_trim
+from faster_whisper.audio import SUPPORTED_AUDIO_BACKENDS, decode_audio, pad_or_trim
 from faster_whisper.feature_extractor import FeatureExtractor
 from faster_whisper.tokenizer import _LANGUAGE_CODES, Tokenizer
 from faster_whisper.utils import download_model, format_timestamp, get_end, get_logger
@@ -384,7 +384,11 @@ class BatchedInferencePipeline:
             multilingual = False
 
         if not isinstance(audio, np.ndarray):
-            audio = decode_audio(audio, sampling_rate=sampling_rate)
+            audio = decode_audio(
+                audio,
+                sampling_rate=sampling_rate,
+                backend=self.model.audio_backend,
+            )
         duration = audio.shape[0] / sampling_rate
 
         self.model.logger.info(
@@ -631,6 +635,7 @@ class WhisperModel:
         files: dict = None,
         revision: Optional[str] = None,
         use_auth_token: Optional[Union[str, bool]] = None,
+        audio_backend: str = "pyav",
         **model_kwargs,
     ):
         """Initializes the Whisper model.
@@ -667,7 +672,20 @@ class WhisperModel:
             commit hash.
           use_auth_token: HuggingFace authentication token or True to use the
             token stored by the HuggingFace config folder.
+          audio_backend: Which backend to use when decoding audio inputs. One of:
+            - "pyav" (default): decode via the PyAV library in-process.
+            - "ffmpeg": shell out to the `ffmpeg` binary. Useful when PyAV
+              cannot be loaded (e.g. Windows 11 Smart App Control blocks the
+              PyAV DLLs, or restricted corporate environments). Requires
+              `ffmpeg` on PATH, or the `FFMPEG_EXE` environment variable.
         """
+        if audio_backend not in SUPPORTED_AUDIO_BACKENDS:
+            raise ValueError(
+                f"Unsupported audio_backend={audio_backend!r}. "
+                f"Expected one of {SUPPORTED_AUDIO_BACKENDS}."
+            )
+        self.audio_backend = audio_backend
+
         self.logger = get_logger()
 
         tokenizer_bytes, preprocessor_bytes = None, None
@@ -873,7 +891,11 @@ class WhisperModel:
             multilingual = False
 
         if not isinstance(audio, np.ndarray):
-            audio = decode_audio(audio, sampling_rate=sampling_rate)
+            audio = decode_audio(
+                audio,
+                sampling_rate=sampling_rate,
+                backend=self.audio_backend,
+            )
 
         duration = audio.shape[0] / sampling_rate
         duration_after_vad = duration

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -1,0 +1,89 @@
+"""Tests for the pluggable audio_backend parameter on WhisperModel.
+
+The goal of these tests is to lock in the public contract of the
+`audio_backend` knob added alongside the PyAV backend:
+
+  1. The default backend ("pyav") still produces the expected float32
+     waveform — no behavior change for existing users.
+  2. The "ffmpeg" backend decodes the same file to an equivalent waveform
+     (within a small tolerance, since both pipelines resample through s16).
+  3. An unknown backend is rejected eagerly, both at `decode_audio` and at
+     `WhisperModel` construction time, with a helpful ValueError.
+  4. When ffmpeg is not on PATH and `FFMPEG_EXE` is unset, the ffmpeg
+     backend raises a RuntimeError with an install hint (we simulate this
+     by monkeypatching the PATH lookup, so the test does not depend on
+     the runner's system state).
+
+These tests intentionally avoid loading the actual Whisper model weights
+(which would require a network download) — they exercise `decode_audio`
+directly, plus WhisperModel's constructor-time validation.
+"""
+
+import os
+import shutil
+
+import numpy as np
+import pytest
+
+from faster_whisper import WhisperModel, decode_audio
+from faster_whisper.audio import SUPPORTED_AUDIO_BACKENDS
+
+
+def _ffmpeg_available() -> bool:
+    return os.environ.get("FFMPEG_EXE") or shutil.which("ffmpeg") is not None
+
+
+def test_supported_backends_listed():
+    assert "pyav" in SUPPORTED_AUDIO_BACKENDS
+    assert "ffmpeg" in SUPPORTED_AUDIO_BACKENDS
+
+
+def test_decode_audio_default_backend_pyav(jfk_path):
+    audio = decode_audio(jfk_path, sampling_rate=16000)
+    assert isinstance(audio, np.ndarray)
+    assert audio.dtype == np.float32
+    # jfk.flac is ~11s at 16kHz → ~176000 samples, give ourselves a loose
+    # bracket so minor resampler differences do not flake this test.
+    assert 150_000 <= audio.shape[0] <= 200_000
+
+
+@pytest.mark.skipif(
+    not _ffmpeg_available(),
+    reason="ffmpeg binary not available on PATH / FFMPEG_EXE",
+)
+def test_decode_audio_ffmpeg_backend_matches_pyav(jfk_path):
+    pyav_audio = decode_audio(jfk_path, sampling_rate=16000, backend="pyav")
+    ff_audio = decode_audio(jfk_path, sampling_rate=16000, backend="ffmpeg")
+
+    assert isinstance(ff_audio, np.ndarray)
+    assert ff_audio.dtype == np.float32
+
+    # Both pipelines go through s16 at 16kHz mono — sample counts should
+    # match to within a frame, and RMS should be very close.
+    assert abs(ff_audio.shape[0] - pyav_audio.shape[0]) < 320  # <20ms drift
+
+    n = min(ff_audio.shape[0], pyav_audio.shape[0])
+    rms_pyav = float(np.sqrt(np.mean(pyav_audio[:n] ** 2)))
+    rms_ff = float(np.sqrt(np.mean(ff_audio[:n] ** 2)))
+    assert abs(rms_pyav - rms_ff) < 1e-2
+
+
+def test_decode_audio_invalid_backend_raises(jfk_path):
+    with pytest.raises(ValueError, match="Unsupported audio_backend"):
+        decode_audio(jfk_path, backend="gstreamer")
+
+
+def test_whisper_model_invalid_audio_backend_raises():
+    # Validation must happen before we touch ctranslate2 / download weights.
+    with pytest.raises(ValueError, match="Unsupported audio_backend"):
+        WhisperModel("tiny.en", audio_backend="gstreamer")
+
+
+def test_decode_audio_ffmpeg_backend_missing_binary_raises(monkeypatch, jfk_path):
+    # Simulate ffmpeg not being installed: clear FFMPEG_EXE and make
+    # shutil.which return None. Everything else stays untouched.
+    monkeypatch.delenv("FFMPEG_EXE", raising=False)
+    monkeypatch.setattr("faster_whisper.audio.shutil.which", lambda _: None)
+
+    with pytest.raises(RuntimeError, match="ffmpeg"):
+        decode_audio(jfk_path, backend="ffmpeg")


### PR DESCRIPTION
## Summary

Adds a new `audio_backend` keyword argument to `WhisperModel.__init__` (and to the lower-level `decode_audio()` helper) that lets callers opt out of PyAV and decode audio via a subprocess call to the `ffmpeg` binary instead.

The default remains `"pyav"` — **no behavior change for existing users**.

## Motivation

PyAV ships precompiled wheels on PyPI. On Windows 11 with Smart App Control (SAC) enabled, CodeIntegrity blocks the PyAV binaries (`pyio.pyd`, `libwebpmux-*.dll`) as not meeting the "Enterprise signing level" requirement. `import av` then crashes with DLL load failures (Event ID 3077 in CodeIntegrity/Operational).

SAC cannot be disabled without reinstalling Windows, which makes `faster-whisper` effectively unusable on corporate / hardened desktops — even though a signed `ffmpeg.exe` (e.g. from `winget install Gyan.FFmpeg`) is readily available on those same machines.

The same escape hatch is useful in other sandboxed contexts (locked-down corporate images, minimal containers) where a system `ffmpeg` is present but arbitrary Python-shipped DLLs cannot be loaded.

Related: the workaround we currently run in production (patching `site-packages/faster_whisper/audio.py` after install) — this PR upstreams that logic behind a clean public flag so nobody needs to monkey-patch the wheel.

## Proposed API

```python
from faster_whisper import WhisperModel

# Default, unchanged behavior
model = WhisperModel("large-v3")

# Opt in to ffmpeg subprocess backend
model = WhisperModel("large-v3", audio_backend="ffmpeg")
```

The same parameter is also accepted on the lower-level helper for callers who use it directly:

```python
from faster_whisper import decode_audio

audio = decode_audio("speech.mp3", backend="ffmpeg")
```

Accepted values: `"pyav"` (default) or `"ffmpeg"`. Anything else raises `ValueError` eagerly — both in `decode_audio` and at `WhisperModel` construction time, before any weights are downloaded.

### ffmpeg binary resolution

When `audio_backend="ffmpeg"` is selected, the binary is resolved in this order:

1. `FFMPEG_EXE` environment variable (absolute path).
2. `shutil.which("ffmpeg")` on `PATH`.
3. Otherwise, raise `RuntimeError` with an install hint.

## Implementation notes

- `faster_whisper/audio.py` is refactored so that `import av` happens **lazily** inside the pyav code path. Users who pick `audio_backend="ffmpeg"` never trigger a PyAV import, which is exactly what SAC-locked environments need.
- The ffmpeg path runs:
  ```
  ffmpeg -nostdin -threads 0 -i <input> -f s16le -ac 1 -acodec pcm_s16le -ar <rate> -loglevel error -
  ```
  and converts the raw PCM stdout to `float32 / 32768.0` via numpy, matching the pyav pipeline byte-for-byte up to resampler rounding.
- File-like inputs are supported via `stdin` piping (mirroring the current pyav behavior).

## Trade-offs

- `audio_backend="ffmpeg"` requires a system `ffmpeg`. This is already a common dependency for many faster-whisper workflows, and it is the only viable path on SAC-protected Windows installs.
- Default stays `"pyav"` — no new runtime dependency unless explicitly opted into.

## Tests

New `tests/test_audio_backend.py` covers:

- Default `pyav` backend decodes the existing `jfk.flac` fixture to `float32` (smoke).
- `ffmpeg` backend produces a matching waveform (length drift < 20 ms, RMS delta < 1e-2) — skipped when `ffmpeg` is not on the runner's `PATH`.
- Invalid backend values are rejected by `decode_audio` and by `WhisperModel.__init__` (validation happens before weight download).
- Missing `ffmpeg` binary is reported as `RuntimeError` with an install hint — simulated via monkeypatched `shutil.which` so the test runs deterministically regardless of host state.

Local run on macOS (M-series, Python 3.9):

```
tests/test_audio_backend.py::test_supported_backends_listed PASSED
tests/test_audio_backend.py::test_decode_audio_default_backend_pyav PASSED
tests/test_audio_backend.py::test_decode_audio_ffmpeg_backend_matches_pyav PASSED
tests/test_audio_backend.py::test_decode_audio_invalid_backend_raises PASSED
tests/test_audio_backend.py::test_whisper_model_invalid_audio_backend_raises PASSED
tests/test_audio_backend.py::test_decode_audio_ffmpeg_backend_missing_binary_raises PASSED
6 passed in 15.53s
```

## README

Short snippet added next to the existing PyAV note, documenting when/why to pick `audio_backend="ffmpeg"` and how to point at a non-PATH binary via `FFMPEG_EXE`.

## Status

**Opened as DRAFT for upstream review.** I will not promote it to Ready until a maintainer has taken a look at the API shape. Happy to adjust — for example, if you'd prefer the flag on `transcribe()` instead of `__init__`, or a different default-resolution strategy for the ffmpeg binary.
