### PR TITLE
Fixes broken export LD_LIBRARY_PATH cmd in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ On Linux these libraries can be installed with `pip`. Note that `LD_LIBRARY_PATH
 ```bash
 pip install nvidia-cublas-cu12 nvidia-cudnn-cu12==9.*
 
-export LD_LIBRARY_PATH=`python3 -c 'import os; import nvidia.cublas.lib; import nvidia.cudnn.lib; print(os.path.dirname(nvidia.cublas.lib.__file__) + ":" + os.path.dirname(nvidia.cudnn.lib.__file__))'`
+export LD_LIBRARY_PATH=$(python3 -c 'import os, nvidia.cublas, nvidia.cudnn; print(os.path.dirname(nvidia.cublas.__path__[0]) + "/cublas/lib:" + os.path.dirname(nvidia.cudnn.__path__[0]) + "/cudnn/lib")')
 ```
 
 #### Download the libraries from Purfview's repository (Windows & Linux)


### PR DESCRIPTION
The current cmd to export the `LD_LIBRARY_PATH` gave the following error on my machine:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<frozen posixpath>", line 181, in dirname
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

This has been reported in issue: https://github.com/SYSTRAN/faster-whisper/issues/1320 and this update fixes the error.

Reason:  In recent versions of nvidia-cublas-cu12 and nvidia-cudnn-cu12, NVIDIA changed how these packages are structured. The submodules are namespaces or do not explicitly declare a __file__ property anymore, returning None across the board.