### PR TITLE
Handle empty alignments in find_alignment (companion to the CTranslate2 divide-by-zero fix for #1342)

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -1717,6 +1717,12 @@ class WhisperModel:
         for result, text_token in zip(results, text_tokens):
             text_token_probs = result.text_token_probs
             alignments = result.alignments
+            if len(alignments) == 0:
+                # No alignment available, e.g. the window was shorter than the
+                # encoder stride so there were no frames to align against
+                # (ctranslate2 returns an empty alignment for such windows).
+                return_list.append([])
+                continue
             text_indices = np.array([pair[0] for pair in alignments])
             time_indices = np.array([pair[1] for pair in alignments])
 


### PR DESCRIPTION
## What

`find_alignment` crashes with `IndexError: boolean index did not match indexed array` at `time_indices[jumps]` when `model.align()` returns an **empty alignment** for a segment. This PR returns an empty word list for such segments instead — the segment simply carries no word timestamps, which `add_word_timestamps` already handles.

## Why

This is the faster-whisper half of the fix for #1342 (process killed with `0xC0000094` on Windows when word-level timestamps are enabled for specific audio files). Root cause and reproduction are detailed in https://github.com/SYSTRAN/faster-whisper/issues/1342#issuecomment-4691582342 and OpenNMT/CTranslate2#2065:

- On some audio Whisper hallucinates a trailing segment past the clip end, and the segmentation/VAD path ends up calling `align()` with `num_frames=1` (a ~10ms window).
- CTranslate2 halves `num_frames` for the encoder stride (1 → 0) and hits an integer division by zero in native code — killing the whole process, uncatchable from Python.
- With the CTranslate2 fix merged, `align()` returns an empty alignment for such windows — and this guard makes faster-whisper handle that gracefully.

## Verification

- A real 60s clip (Turkish, large-v3, CUDA, `word_timestamps=True, vad_filter=True`) that previously killed the process on every attempt now transcribes completely with both patches: 17 real segments with word timestamps, plus the trailing hallucinated segment (60.0→90.0s on 60.01s of audio) with no words.
- `pytest tests/`: 17 passed; the 2 failures (`test_transcribe`, `test_multilingual_transcription` — exact-transcript assertions) fail identically on a pristine checkout of master in the same environment, i.e. pre-existing and unrelated.
- `black`, `isort`, `flake8` all clean.

## AI assistance disclosure

I used an AI assistant (Claude) to help trace the crash and draft the patch; I directed the investigation and verified the behavior empirically (instrumented `align()` capture, local patched CTranslate2 build, the real-world clip, and the test suite). I am responsible for the change.