### PR TITLE
[Fix] decode_audio crashes on mid-stream sample rate/format changes (#1451)

### DIFF
--- a/faster_whisper/audio.py
+++ b/faster_whisper/audio.py
@@ -46,8 +46,8 @@ def decode_audio(
     with av.open(input_file, mode="r", metadata_errors="ignore") as container:
         frames = container.decode(audio=0)
         frames = _ignore_invalid_frames(frames)
-        frames = _group_frames(frames, 500000)
         frames = _resample_frames(frames, resampler)
+        frames = _group_frames(frames, 500000)
 
         for frame in frames:
             array = frame.to_ndarray()


### PR DESCRIPTION
## Motivation

`decode_audio` raises `ValueError: Frame does not match AudioFifo parameters` on audio whose sample rate or sample format changes partway through the stream (#1451, which includes a repro file).

## Root cause

The decode pipeline groups frames *before* resampling:

```python
frames = _ignore_invalid_frames(frames)
frames = _group_frames(frames, 500000)        # AudioFifo locks to the first frame's params
frames = _resample_frames(frames, resampler)
```

`_group_frames` writes every decoded frame into a single `av.audio.fifo.AudioFifo()`, which fixes its parameters on the first frame and rejects any later frame with a different sample rate/format. So the crash happens in `_group_frames`, before the `AudioResampler` (which would normalize the frames) ever runs.

## Modifications

`faster_whisper/audio.py` (`decode_audio`): resample before grouping. `_resample_frames` normalizes every frame to `s16` / the target layout / `sampling_rate`, so `_group_frames` then only ever sees uniform frames. The `AudioResampler` is stateful across calls, so resampling frame-by-frame before batching yields the same samples as the previous order.

## Duplicate-check

- Track A — `gh api 'repos/SYSTRAN/faster-whisper/pulls?state=open --paginate'` grepped for `1451` → no open PR references the issue.
- Track B — issue #1451 (state OPEN) has 0 comments and no in-progress claim.
