### PR TITLE
Add optional language-aware VAD segmentation for multilingual inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,15 @@ for segment in segments:
         print("[%.2fs -> %.2fs] %s" % (word.start, word.end, word.word))
 ```
 
+### Multilingual transcription
+
+```python
+segments, _ = model.transcribe("audio.mp3", multilingual=True)
+
+for segment in segments:
+    print("[%.2fs -> %.2fs] (%s) %s" % (segment.start, segment.end, segment.language, segment.text))
+```
+
 ### VAD filter
 
 The library integrates the [Silero VAD](https://github.com/snakers4/silero-vad) model to filter out parts of the audio without speech:

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -148,6 +148,7 @@ class BatchedInferencePipeline:
                     {
                         "start": cur_start / sampling_rate,
                         "end": cur_end / sampling_rate,
+                        "language": cur_lang,
                     }
                 )
 
@@ -220,7 +221,7 @@ class BatchedInferencePipeline:
             )
 
         encoder_output, outputs = self.generate_segment_batched(
-            features, tokenizer, options
+            features, tokenizer, options, [m.get("language") for m in chunks_metadata]
         )
 
         segmented_outputs = []
@@ -301,6 +302,7 @@ class BatchedInferencePipeline:
         features: np.ndarray,
         tokenizer: Tokenizer,
         options: TranscriptionOptions,
+        window_languages: Optional[List[Optional[str]]] = None,
     ):
         batch_size = features.shape[0]
 
@@ -344,6 +346,18 @@ class BatchedInferencePipeline:
 
             for i, language_token in enumerate(language_tokens):
                 prompts[i][language_token_index] = language_token
+
+            # Override auto-detected language with the splitter's label when
+            # the window carries a confident language. This prevents the auto-
+            # detector from misclassifying a window that is predominantly one
+            # language but contains a minority of another.
+            if window_languages is not None:
+                for i, wl in enumerate(window_languages):
+                    if wl is not None:
+                        language_tokens[i] = tokenizer.tokenizer.token_to_id(
+                            f"<|{wl}|>"
+                        )
+                        prompts[i][language_token_index] = language_tokens[i]
 
             self.model.logger.debug(
                 "Multilingual batched: per-chunk languages: %s",
@@ -652,7 +666,11 @@ class BatchedInferencePipeline:
         else:
             clip_timestamps_provided = True
             clip_timestamps = [
-                {k: int(v * sampling_rate) for k, v in segment.items()}
+                {
+                    "start": int(segment["start"] * sampling_rate),
+                    "end": int(segment["end"] * sampling_rate),
+                    "language": segment.get("language"),
+                }
                 for segment in clip_timestamps
             ]
 
@@ -674,6 +692,7 @@ class BatchedInferencePipeline:
                         "offset": clip["start"] / sampling_rate,
                         "duration": clip_duration,
                         "segments": [clip],
+                        "language": clip.get("language"),
                     }
                 )
 
@@ -1452,6 +1471,11 @@ class WhisperModel:
                 if clip_idx < len(seek_clips):
                     seek = seek_clips[clip_idx][0]
                 continue
+
+            # If this window extends beyond the clip's content, clamp the end
+            # so we process the visible portion. Without this, the decoder skips
+            # the window entirely and audio near clip boundaries is silently lost.
+            effective_clip_end = min(seek_clip_end, content_frames)
             time_offset = seek * self.feature_extractor.time_per_frame
             window_end_time = float(
                 (seek + self.feature_extractor.nb_max_frames)
@@ -1460,7 +1484,7 @@ class WhisperModel:
             segment_size = min(
                 self.feature_extractor.nb_max_frames,
                 content_frames - seek,
-                seek_clip_end - seek,
+                effective_clip_end - seek,
             )
             segment = features[:, seek : seek + segment_size]
             segment_duration = segment_size * self.feature_extractor.time_per_frame

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -51,6 +51,7 @@ class Segment:
     start: float
     end: float
     text: str
+    language: str
     tokens: List[int]
     avg_logprob: float
     compression_ratio: float
@@ -148,6 +149,9 @@ class BatchedInferencePipeline:
                         tokens=subsegment["tokens"],
                         start=subsegment["start"],
                         end=subsegment["end"],
+                        language=tokenizer.tokenizer.id_to_token(
+                            output["language_token"]
+                        )[2:-2],
                         compression_ratio=get_compression_ratio(
                             tokenizer.decode(subsegment["tokens"])
                         ),
@@ -218,6 +222,8 @@ class BatchedInferencePipeline:
 
             for i, language_token in enumerate(language_tokens):
                 prompts[i][language_token_index] = language_token
+        else:
+            language_tokens = [tokenizer.language] * batch_size
 
         results = self.model.model.generate(
             encoder_output,
@@ -236,7 +242,7 @@ class BatchedInferencePipeline:
         )
 
         output = []
-        for result in results:
+        for idx, result in enumerate(results):
             # return scores
             seq_len = len(result.sequences_ids[0])
             cum_logprob = result.scores[0] * (seq_len**options.length_penalty)
@@ -246,6 +252,7 @@ class BatchedInferencePipeline:
                     avg_logprob=cum_logprob / (seq_len + 1),
                     no_speech_prob=result.no_speech_prob,
                     tokens=result.sequences_ids[0],
+                    language_token=language_tokens[idx],
                 )
             )
 
@@ -609,6 +616,7 @@ class BatchedInferencePipeline:
                         no_speech_prob=segment["no_speech_prob"],
                         compression_ratio=segment["compression_ratio"],
                         temperature=options.temperatures[0],
+                        language=segment["language"],
                     )
 
                 pbar.update(1)
@@ -1357,6 +1365,7 @@ class WhisperModel:
                     start=segment["start"],
                     end=segment["end"],
                     text=text,
+                    language=tokenizer.language_code,
                     tokens=tokens,
                     temperature=temperature,
                     avg_logprob=avg_logprob,

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -7,7 +7,7 @@ import zlib
 from dataclasses import asdict, dataclass
 from inspect import signature
 from math import ceil
-from typing import BinaryIO, Iterable, List, Optional, Tuple, Union
+from typing import BinaryIO, Dict, Iterable, List, Optional, Tuple, Union
 from warnings import warn
 
 import ctranslate2
@@ -92,6 +92,7 @@ class TranscriptionOptions:
     prepend_punctuations: str
     append_punctuations: str
     multilingual: bool
+    language_aware_vad_segments: bool
     max_new_tokens: Optional[int]
     clip_timestamps: Union[str, List[float]]
     hallucination_silence_threshold: Optional[float]
@@ -117,14 +118,105 @@ class BatchedInferencePipeline:
         self.model: WhisperModel = model
         self.last_speech_timestamp = 0.0
 
+    @staticmethod
+    def _group_chunks_by_language(
+        sub_chunks: List[dict],
+        sampling_rate: int,
+        chunk_length: float,
+        max_gap_s: float = 2.0,
+    ) -> List[dict]:
+        """Group consecutive same-language sub-chunks into <= chunk_length windows.
+
+        Windows keep their original audio coordinates: the silence between
+        sub-chunks is *not* packed away, so each window is a contiguous slice of
+        the original audio and timestamps need no restoration. The model's own
+        per-window language detection (run later in ``generate_segment_batched``)
+        picks the actual decode language; this grouping only keeps windows
+        monolingual so that detection is not confused by a mid-window switch.
+
+        ``max_gap_s`` bounds how much silence may be folded into a window when
+        merging same-language sub-chunks, so a long pause starts a fresh window.
+        """
+        windows: List[dict] = []
+        cur_start: Optional[int] = None
+        cur_end: Optional[int] = None
+        cur_lang: Optional[str] = None
+        # A run of unconfident (None) sub-chunks is kept pending rather than
+        # emitted on its own: it gets folded into the following confident window
+        # (or the current one, if it still fits). This avoids tiny standalone
+        # windows whose language the model can't determine reliably.
+        pending_start: Optional[int] = None
+
+        def flush():
+            if cur_start is not None:
+                windows.append(
+                    {
+                        "start": cur_start / sampling_rate,
+                        "end": cur_end / sampling_rate,
+                    }
+                )
+
+        for sc in sub_chunks:
+            s = int(sc["start"])
+            e = int(sc["end"])
+            lang = sc.get("language")
+
+            if lang is None:
+                # Fold into the current window if it still fits, otherwise carry
+                # the span forward to attach to the next confident window.
+                if (
+                    cur_start is not None
+                    and (e - cur_start) / sampling_rate <= chunk_length
+                    and (s - cur_end) / sampling_rate <= max_gap_s
+                ):
+                    cur_end = e
+                else:
+                    if pending_start is None:
+                        pending_start = s
+                continue
+
+            same_language = cur_start is not None and lang == cur_lang
+            prospective_start = (
+                pending_start if pending_start is not None else cur_start
+            )
+            within_length = (
+                e - (prospective_start or s)
+            ) / sampling_rate <= chunk_length
+            small_gap = (
+                cur_end is not None and (s - cur_end) / sampling_rate <= max_gap_s
+            ) or pending_start is not None
+
+            if same_language and within_length and (cur_start is None or small_gap):
+                if pending_start is not None:
+                    cur_start = pending_start
+                cur_end = e
+                pending_start = None
+                continue
+
+            flush()
+            cur_start = pending_start if pending_start is not None else s
+            cur_end = e
+            cur_lang = lang
+            pending_start = None
+        flush()
+        return windows
+
     def forward(self, features, tokenizer, chunks_metadata, options):
+        if options.multilingual:
+            self.model.logger.debug(
+                "Multilingual batched: forward with %d chunk(s), batch features "
+                "shape %s",
+                len(chunks_metadata),
+                features.shape,
+            )
+
         encoder_output, outputs = self.generate_segment_batched(
             features, tokenizer, options
         )
 
         segmented_outputs = []
         segment_sizes = []
-        for chunk_metadata, output in zip(chunks_metadata, outputs):
+        for j, (chunk_metadata, output) in enumerate(zip(chunks_metadata, outputs)):
             duration = chunk_metadata["duration"]
             segment_size = int(ceil(duration) * self.model.frames_per_second)
             segment_sizes.append(segment_size)
@@ -140,6 +232,26 @@ class BatchedInferencePipeline:
                 segment_duration=duration,
                 seek=0,
             )
+
+            n_tokens = len(output["tokens"])
+            lang_token_id = output["language_token"]
+            lang_str = (
+                tokenizer.tokenizer.id_to_token(lang_token_id)
+                if lang_token_id is not None
+                else "?"
+            )[2:-2]
+
+            self.model.logger.debug(
+                "Multilingual batched: chunk %d decoded: %d tokens, lang=%s, "
+                "no_speech_prob=%.3f, avg_logprob=%.3f, subsegments=%d",
+                j,
+                n_tokens,
+                lang_str,
+                output["no_speech_prob"],
+                output["avg_logprob"],
+                len(subsegments),
+            )
+
             segmented_outputs.append(
                 [
                     dict(
@@ -214,14 +326,24 @@ class BatchedInferencePipeline:
         prompts = [prompt.copy() for _ in range(batch_size)]
 
         if options.multilingual:
+            detected_languages = self.model.model.detect_language(encoder_output)
             language_tokens = [
                 tokenizer.tokenizer.token_to_id(segment_langs[0][0])
-                for segment_langs in self.model.model.detect_language(encoder_output)
+                for segment_langs in detected_languages
             ]
             language_token_index = prompt.index(tokenizer.language)
 
             for i, language_token in enumerate(language_tokens):
                 prompts[i][language_token_index] = language_token
+
+            self.model.logger.debug(
+                "Multilingual batched: per-chunk languages: %s",
+                ", ".join(
+                    f"chunk-{i}: {detected_languages[i][0][0][2:-2]} "
+                    f"({detected_languages[i][0][1]:.2f})"
+                    for i in range(len(detected_languages))
+                ),
+            )
         else:
             language_tokens = [tokenizer.language] * batch_size
 
@@ -293,6 +415,7 @@ class BatchedInferencePipeline:
         prepend_punctuations: str = "\"'“¿([{-",
         append_punctuations: str = "\"'.。,，!！?？:：”)]}、",
         multilingual: bool = False,
+        language_aware_vad_segments: bool = False,
         vad_filter: bool = True,
         vad_parameters: Optional[Union[dict, VadOptions]] = None,
         max_new_tokens: Optional[int] = None,
@@ -336,6 +459,12 @@ class BatchedInferencePipeline:
             append_punctuations: If word_timestamps is True, merge these punctuation symbols
                 with the previous word
             multilingual: Perform language detection on every segment.
+            language_aware_vad_segments: Split VAD speech chunks at detected language change
+                points before batching, so each batch window is monolingual. This prevents
+                a single language token being applied across a mid-window language switch
+                (which truncates and mis-transcribes the other language). Only effective when
+                ``multilingual=True`` and ``vad_filter=True``. Adds an extra detection pass
+                over the speech chunks (~3x slower) and is therefore opt-in.
             vad_filter: Enable the voice activity detection (VAD) to filter out parts of the audio
                 without speech. This step is using the Silero VAD model
                 https://github.com/snakers4/silero-vad.
@@ -399,6 +528,74 @@ class BatchedInferencePipeline:
         )
 
         chunk_length = chunk_length or self.model.feature_extractor.chunk_length
+
+        # When the caller opts into language-aware VAD segmentation, build the
+        # batch windows from VAD speech chunks split at detected language change
+        # points so each window is monolingual. This prevents a single language
+        # token being applied across a mid-window language switch (which truncates
+        # and mis-transcribes the other language). On by request only: it adds an
+        # extra detection pass over the speech chunks (~3x slower).
+        if multilingual and language_aware_vad_segments and not clip_timestamps:
+            # Use the same VAD defaults as the non-multilingual batched path so the
+            # speech chunks (and thus our language-aligned windows) are capped at
+            # chunk_length, unless the caller overrides them.
+            if vad_parameters is None:
+                vad_options = VadOptions(
+                    max_speech_duration_s=chunk_length,
+                    min_silence_duration_ms=160,
+                )
+            elif isinstance(vad_parameters, dict):
+                overrides = dict(vad_parameters)
+                overrides.setdefault("max_speech_duration_s", chunk_length)
+                overrides.setdefault("min_silence_duration_ms", 160)
+                vad_options = VadOptions(**overrides)
+            else:
+                vad_options = vad_parameters
+
+            if vad_filter:
+                speech_chunks = get_speech_timestamps(audio, vad_options)
+                self.model.logger.debug(
+                    "Multilingual batched: %d VAD speech chunk(s): %s",
+                    len(speech_chunks),
+                    ", ".join(
+                        "[%s – %s]"
+                        % (
+                            format_timestamp(c["start"] / sampling_rate),
+                            format_timestamp(c["end"] / sampling_rate),
+                        )
+                        for c in speech_chunks
+                    ),
+                )
+
+                sub_chunks = self.model._split_vad_chunks_by_language(
+                    audio, speech_chunks, sampling_rate
+                )
+
+                clip_timestamps = self._group_chunks_by_language(
+                    sub_chunks, sampling_rate, chunk_length
+                )
+            else:
+                clip_timestamps = [
+                    {
+                        "start": i * chunk_length,
+                        "end": min((i + 1) * chunk_length, duration),
+                    }
+                    for i in range(int(np.ceil(duration / chunk_length)))
+                ]
+
+            self.model.logger.debug(
+                "Multilingual batched: %d language-aligned window(s): %s",
+                len(clip_timestamps),
+                ", ".join(
+                    "[%s – %s]"
+                    % (
+                        format_timestamp(w["start"]),
+                        format_timestamp(w["end"]),
+                    )
+                    for w in clip_timestamps
+                ),
+            )
+
         # if no segment split is provided, use vad_model and generate segments
         if not clip_timestamps:
             if vad_filter:
@@ -439,7 +636,8 @@ class BatchedInferencePipeline:
 
             audio_chunks, chunks_metadata = [], []
             for i, clip in enumerate(clip_timestamps):
-                audio_chunks.append(audio[clip["start"] : clip["end"]])
+                audio_chunk = audio[clip["start"] : clip["end"]]
+                audio_chunks.append(audio_chunk)
 
                 clip_duration = (clip["end"] - clip["start"]) / sampling_rate
                 if clip_duration > 30:
@@ -455,6 +653,16 @@ class BatchedInferencePipeline:
                         "duration": clip_duration,
                         "segments": [clip],
                     }
+                )
+
+                self.model.logger.debug(
+                    "Multilingual batched: chunk %d → [%.3f – %.3f] (%.2f s) "
+                    "%d audio samples",
+                    i,
+                    clip["start"] / sampling_rate,
+                    clip["end"] / sampling_rate,
+                    clip_duration,
+                    len(audio_chunk),
                 )
 
         duration_after_vad = (
@@ -555,6 +763,7 @@ class BatchedInferencePipeline:
             clip_timestamps=clip_timestamps,
             prompt_reset_on_temperature=0.5,
             multilingual=multilingual,
+            language_aware_vad_segments=language_aware_vad_segments,
             without_timestamps=without_timestamps,
             max_initial_timestamp=0.0,
         )
@@ -600,6 +809,16 @@ class BatchedInferencePipeline:
             for result in results:
                 for segment in result:
                     seg_idx += 1
+                    if options.multilingual:
+                        self.model.logger.debug(
+                            "Multilingual batched: yielded segment (id=%d) "
+                            "[%.3f – %.3f] lang=%s text=%r",
+                            seg_idx,
+                            round(segment["start"], 3),
+                            round(segment["end"], 3),
+                            segment["language"],
+                            segment["text"][:200],
+                        )
                     yield Segment(
                         seek=segment["seek"],
                         id=seg_idx,
@@ -787,6 +1006,7 @@ class WhisperModel:
         prepend_punctuations: str = "\"'“¿([{-",
         append_punctuations: str = "\"'.。,，!！?？:：”)]}、",
         multilingual: bool = False,
+        language_aware_vad_segments: bool = False,
         vad_filter: bool = False,
         vad_parameters: Optional[Union[dict, VadOptions]] = None,
         max_new_tokens: Optional[int] = None,
@@ -844,6 +1064,11 @@ class WhisperModel:
           append_punctuations: If word_timestamps is True, merge these punctuation symbols
             with the previous word
           multilingual: Perform language detection on every segment.
+          language_aware_vad_segments: Split VAD speech chunks at detected language change points,
+            routing each language-aligned region as its own seek clip so the seek loop processes
+            them separately and re-detects language within each. Only effective when
+            ``multilingual=True`` and ``vad_filter=True``. Off by default (the seek loop already
+            handles boundaries reasonably); opt in for tighter language alignment.
           vad_filter: Enable the voice activity detection (VAD) to filter out parts of the audio
             without speech. This step is using the Silero VAD model
             https://github.com/snakers4/silero-vad.
@@ -896,8 +1121,39 @@ class WhisperModel:
             elif isinstance(vad_parameters, dict):
                 vad_parameters = VadOptions(**vad_parameters)
             speech_chunks = get_speech_timestamps(audio, vad_parameters)
-            audio_chunks, chunks_metadata = collect_chunks(audio, speech_chunks)
-            audio = np.concatenate(audio_chunks, axis=0)
+
+            if multilingual and language_aware_vad_segments:
+                # Split the VAD speech chunks at detected language change points and
+                # route each region as its own seek clip (a flat [start, end, ...]
+                # list in seconds). The seek loop in ``generate_segments`` then
+                # processes each language-aligned region separately and
+                # re-detects language within it; the audio is left intact (no
+                # concat) so the timestamps already reference the original audio.
+                sub_chunks = self._split_vad_chunks_by_language(
+                    audio, speech_chunks, sampling_rate
+                )
+                clip_timestamps = [
+                    ts
+                    for sc in sub_chunks
+                    for ts in (sc["start"] / sampling_rate, sc["end"] / sampling_rate)
+                ]
+                self.logger.debug(
+                    "Language-aware VAD: %d speech chunk(s) -> %d language-aligned "
+                    "region(s): %s",
+                    len(speech_chunks),
+                    len(sub_chunks),
+                    ", ".join(
+                        "[%s -> %s]"
+                        % (
+                            format_timestamp(sc["start"] / sampling_rate),
+                            format_timestamp(sc["end"] / sampling_rate),
+                        )
+                        for sc in sub_chunks
+                    ),
+                )
+            else:
+                audio_chunks, chunks_metadata = collect_chunks(audio, speech_chunks)
+                audio = np.concatenate(audio_chunks, axis=0)
             duration_after_vad = audio.shape[0] / sampling_rate
 
             self.logger.info(
@@ -1004,6 +1260,7 @@ class WhisperModel:
             prepend_punctuations=prepend_punctuations,
             append_punctuations=append_punctuations,
             multilingual=multilingual,
+            language_aware_vad_segments=language_aware_vad_segments,
             max_new_tokens=max_new_tokens,
             clip_timestamps=clip_timestamps,
             hallucination_silence_threshold=hallucination_silence_threshold,
@@ -1407,6 +1664,147 @@ class WhisperModel:
         features = get_ctranslate2_storage(features)
 
         return self.model.encode(features, to_cpu=to_cpu)
+
+    def _split_vad_chunks_by_language(
+        self,
+        audio: np.ndarray,
+        speech_chunks: List[dict],
+        sampling_rate: int,
+    ) -> List[dict]:
+        """Refine VAD speech chunks by splitting them at detected language changes.
+
+        Batched multilingual inference assigns one language token per window. A
+        single chunk that spans a language switch therefore gets one token and the
+        speech of the other language is mis-transcribed (and often truncated), which
+        shows up as "missing" audio. This slides a short detection window over each
+        sufficiently long chunk, batch-detects the language at every position, and
+        splits a chunk wherever the confidently detected language changes.
+
+        Returns a list of ``{"start", "end", "language"}`` dicts whose ``start``/
+        ``end`` are in samples and ``language`` is the detected language code (or
+        ``None`` when no confident detection was made for a chunk).
+        """
+        # Detection resolution. 3 s is the shortest window on which Whisper's
+        # language head reliably separates close languages (e.g. Dutch vs German
+        # on the tiny model), while still localising a mid-chunk switch to within
+        # ~half a second. Hop half the window to overlap detections.
+        window_samples = int(round(3.0 * sampling_rate))
+        hop_samples = int(round(1.5 * sampling_rate))
+        min_subchunk_samples = int(round(0.5 * sampling_rate))
+        min_confidence = 0.5
+        detect_batch = 64
+
+        def _detect(audios):
+            """Batch-encode + detect_language, returning one (lang, prob) per input."""
+            out = []
+            for offset in range(0, len(audios), detect_batch):
+                batch = audios[offset : offset + detect_batch]
+                features = np.stack(
+                    [pad_or_trim(self.feature_extractor(wa)[..., :-1]) for wa in batch]
+                )
+                encoder_output = self.encode(features)
+                for lang_probs in self.model.detect_language(encoder_output):
+                    token, prob = lang_probs[0]
+                    out.append((token[2:-2], float(prob)))
+            return out
+
+        # Detect only the first and last detection window of each chunk.
+        # If they're not the same, apply an overlapping slide to determine the switch.
+        screen_audios: List[np.ndarray] = []
+        screen_meta: List[Tuple[int, str]] = []  # (chunk_idx, "first" | "last")
+        for chunk_idx, chunk in enumerate(speech_chunks):
+            start, end = int(chunk["start"]), int(chunk["end"])
+            # Shorter chunks can't be split and folded into a neighbour during
+            # grouping, so don't spend a detection on their language here.
+            if end - start < window_samples:
+                continue
+            screen_audios.append(audio[start : start + window_samples])
+            screen_meta.append((chunk_idx, "first"))
+            if end - start > window_samples:
+                screen_audios.append(audio[end - window_samples : end])
+                screen_meta.append((chunk_idx, "last"))
+
+        per_chunk_lang: List[Optional[str]] = [None] * len(speech_chunks)
+        needs_refine: List[int] = []
+        if screen_audios:
+            screen_results = _detect(screen_audios)
+            first_lang: Dict[int, Optional[str]] = {}
+            last_lang: Dict[int, Optional[str]] = {}
+            for (chunk_idx, which), (lang, prob) in zip(screen_meta, screen_results):
+                lng = lang if prob >= min_confidence else None
+                if which == "first":
+                    first_lang[chunk_idx] = lng
+                else:
+                    last_lang[chunk_idx] = lng
+            for chunk_idx in range(len(speech_chunks)):
+                fl, ll = first_lang.get(chunk_idx), last_lang.get(chunk_idx)
+                if fl is not None and fl == ll:
+                    per_chunk_lang[chunk_idx] = fl
+                elif fl is None and ll is None:
+                    per_chunk_lang[chunk_idx] = None
+                else:
+                    # Ends disagree (or one is unconfident): refine.
+                    needs_refine.append(chunk_idx)
+
+        # Sliding refine over only the chunks flagged above.
+        refine_windows: List[np.ndarray] = []
+        refine_coords: List[Tuple[int, int]] = []
+        for chunk_idx in needs_refine:
+            start, end = int(speech_chunks[chunk_idx]["start"]), int(
+                speech_chunks[chunk_idx]["end"]
+            )
+            pos = start
+            while pos + window_samples <= end:
+                refine_windows.append(audio[pos : pos + window_samples])
+                refine_coords.append((chunk_idx, pos + window_samples // 2))
+                pos += hop_samples
+
+        refine_detections: Dict[int, List[Tuple[int, str, float]]] = {}
+        if refine_windows:
+            refine_results = _detect(refine_windows)
+            for (chunk_idx, center), (lang, prob) in zip(refine_coords, refine_results):
+                refine_detections.setdefault(chunk_idx, []).append((center, lang, prob))
+
+        refined: List[dict] = []
+        for chunk_idx, chunk in enumerate(speech_chunks):
+            start, end = int(chunk["start"]), int(chunk["end"])
+            if chunk_idx not in needs_refine:
+                refined.append(
+                    {"start": start, "end": end, "language": per_chunk_lang[chunk_idx]}
+                )
+                continue
+
+            detections = refine_detections.get(chunk_idx, [])
+            boundaries = [start]
+            segment_languages: List[Optional[str]] = []
+            last_language: Optional[str] = None
+            for center, language, prob in detections:
+                if prob < min_confidence:
+                    continue
+                if last_language is None:
+                    last_language = language
+                    continue
+                if (
+                    language != last_language
+                    and center - boundaries[-1] >= min_subchunk_samples
+                    and end - center >= min_subchunk_samples
+                ):
+                    boundaries.append(center)
+                    segment_languages.append(last_language)
+                    last_language = language
+            boundaries.append(end)
+            segment_languages.append(last_language)
+
+            for i in range(len(boundaries) - 1):
+                refined.append(
+                    {
+                        "start": boundaries[i],
+                        "end": boundaries[i + 1],
+                        "language": segment_languages[i],
+                    }
+                )
+
+        return refined
 
     def generate_with_fallback(
         self,

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -141,11 +141,6 @@ class BatchedInferencePipeline:
         cur_start: Optional[int] = None
         cur_end: Optional[int] = None
         cur_lang: Optional[str] = None
-        # A run of unconfident (None) sub-chunks is kept pending rather than
-        # emitted on its own: it gets folded into the following confident window
-        # (or the current one, if it still fits). This avoids tiny standalone
-        # windows whose language the model can't determine reliably.
-        pending_start: Optional[int] = None
 
         def flush():
             if cur_start is not None:
@@ -162,42 +157,56 @@ class BatchedInferencePipeline:
             lang = sc.get("language")
 
             if lang is None:
-                # Fold into the current window if it still fits, otherwise carry
-                # the span forward to attach to the next confident window.
-                if (
+                # Unconfident chunks: flush the current confident window and
+                # start/extend a None window. This prevents None chunks at
+                # language boundaries from being folded into the preceding
+                # language's window, which would bridge across a language
+                # switch and confuse the model's per-window detection.
+                if cur_lang is not None:
+                    flush()
+                    cur_start = s
+                    cur_end = e
+                    cur_lang = None
+                elif (
                     cur_start is not None
-                    and (e - cur_start) / sampling_rate <= chunk_length
                     and (s - cur_end) / sampling_rate <= max_gap_s
+                    and (e - cur_start) / sampling_rate <= chunk_length
                 ):
+                    # Extend the current None window.
                     cur_end = e
                 else:
-                    if pending_start is None:
-                        pending_start = s
+                    flush()
+                    cur_start = s
+                    cur_end = e
+                    cur_lang = None
                 continue
 
             same_language = cur_start is not None and lang == cur_lang
-            prospective_start = (
-                pending_start if pending_start is not None else cur_start
-            )
             within_length = (
-                e - (prospective_start or s)
+                e - (cur_start if cur_start is not None else s)
             ) / sampling_rate <= chunk_length
-            small_gap = (
+            small_gap = cur_start is not None and (
                 cur_end is not None and (s - cur_end) / sampling_rate <= max_gap_s
-            ) or pending_start is not None
+            )
 
-            if same_language and within_length and (cur_start is None or small_gap):
-                if pending_start is not None:
-                    cur_start = pending_start
+            if cur_lang is None and within_length and small_gap:
+                # Treat an unconfident boundary span as leading context for the
+                # next confident language. This avoids decoding a short German
+                # prefix (for example, "Jedem") as a standalone English window.
                 cur_end = e
-                pending_start = None
+                cur_lang = lang
                 continue
 
+            if same_language and within_length and small_gap:
+                cur_end = e
+                continue
+
+            # Different language, a gap, or a full window starts a new window.
             flush()
-            cur_start = pending_start if pending_start is not None else s
+            cur_start = s
             cur_end = e
             cur_lang = lang
-            pending_start = None
+
         flush()
         return windows
 
@@ -569,6 +578,19 @@ class BatchedInferencePipeline:
 
                 sub_chunks = self.model._split_vad_chunks_by_language(
                     audio, speech_chunks, sampling_rate
+                )
+                self.model.logger.debug(
+                    "Multilingual batched: %d sub-chunk(s) from language split: %s",
+                    len(sub_chunks),
+                    ", ".join(
+                        "[%s – %s](%s)"
+                        % (
+                            format_timestamp(sc["start"] / sampling_rate),
+                            format_timestamp(sc["end"] / sampling_rate),
+                            sc.get("language"),
+                        )
+                        for sc in sub_chunks
+                    ),
                 )
 
                 clip_timestamps = self._group_chunks_by_language(

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -36,6 +36,7 @@ def test_transcribe(jfk_path):
         " And so my fellow Americans, ask not what your country can do for you, "
         "ask what you can do for your country."
     )
+    assert segment.language == "en"
 
     assert segment.text == "".join(word.word for word in segment.words)
     assert segment.start == segment.words[0].start
@@ -49,7 +50,12 @@ def test_transcribe(jfk_path):
     segments = []
     for segment in result:
         segments.append(
-            {"start": segment.start, "end": segment.end, "text": segment.text}
+            {
+                "start": segment.start,
+                "end": segment.end,
+                "text": segment.text,
+                "language": segment.language,
+            }
         )
 
     assert len(segments) == 1
@@ -57,6 +63,7 @@ def test_transcribe(jfk_path):
         " And so my fellow Americans ask not what your country can do for you, "
         "ask what you can do for your country."
     )
+    assert segment.language == "en"
 
 
 def test_batched_transcribe(physcisworks_path):
@@ -68,7 +75,12 @@ def test_batched_transcribe(physcisworks_path):
     segments = []
     for segment in result:
         segments.append(
-            {"start": segment.start, "end": segment.end, "text": segment.text}
+            {
+                "start": segment.start,
+                "end": segment.end,
+                "text": segment.text,
+                "language": segment.language,
+            }
         )
     # number of near 30 sec segments
     assert len(segments) == 6
@@ -182,6 +194,7 @@ def test_multilingual_transcription(data_dir):
         " notice and this permission notice, shall be included in all copies or substantial "
         "portions of the software."
     )
+    assert segments[0].language == "en"
 
     assert (
         segments[1].text
@@ -192,6 +205,7 @@ def test_multilingual_transcription(data_dir):
         "unterzulizenzieren und oder kopieren der Software zu verkaufen und diese Rechte "
         "unterfolgen den Bedingungen anderen zu übertragen."
     )
+    assert segments[1].language == "de"
 
     segments, info = pipeline.transcribe(audio, multilingual=True)
     segments = list(segments)
@@ -206,12 +220,14 @@ def test_multilingual_transcription(data_dir):
         " notice and this permission notice, shall be included in all copies or substantial "
         "portions of the software."
     )
+    assert segments[0].language == "en"
     assert (
         "Dokumentationsdatein erhält, wird hiermit unengeltlich die Genehmigung erteilt,"
         " wird der Software und eingeschränkt zu verfahren. Dies umfasst insbesondere das Recht,"
         " die Software zu verwenden, zu vervielfältigen, zu modifizieren"
         in segments[1].text
     )
+    assert segments[1].language == "de"
 
 
 def test_hotwords(data_dir):

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -229,6 +229,19 @@ def test_multilingual_transcription(data_dir):
     )
     assert segments[1].language == "de"
 
+    segments, info = pipeline.transcribe(
+        audio,
+        multilingual=True,
+        language_aware_vad_segments=True,
+        without_timestamps=True,
+        condition_on_previous_text=False,
+    )
+    segments = list(segments)
+    assert info.transcription_options.language_aware_vad_segments is True
+    assert segments[0].language == "en"
+    assert segments[1].language == "de"
+    assert segments[1].text.startswith(" Jedem")
+
 
 def test_hotwords(data_dir):
     model = WhisperModel("tiny")

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -272,9 +272,9 @@ def test_group_chunks_by_language_emits_distant_none_window():
     # The None span (30–40s) is too far from the de chunk (60–70s) to merge,
     # so it must be emitted as its own window rather than dropped.
     assert len(windows) == 3
-    assert windows[0] == {"start": 0.0, "end": 10.0}
-    assert windows[1] == {"start": 30.0, "end": 40.0}
-    assert windows[2] == {"start": 60.0, "end": 70.0}
+    assert windows[0] == {"start": 0.0, "end": 10.0, "language": "en"}
+    assert windows[1] == {"start": 30.0, "end": 40.0, "language": None}
+    assert windows[2] == {"start": 60.0, "end": 70.0, "language": "de"}
 
 
 def test_hotwords(data_dir):

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 
 from faster_whisper import BatchedInferencePipeline, WhisperModel, decode_audio
+from faster_whisper.transcribe import BatchedInferencePipeline as _BatchedPipeline
 
 
 def test_supported_languages():
@@ -239,8 +240,41 @@ def test_multilingual_transcription(data_dir):
     segments = list(segments)
     assert info.transcription_options.language_aware_vad_segments is True
     assert segments[0].language == "en"
-    assert segments[1].language == "de"
-    assert segments[1].text.startswith(" Jedem")
+    german_segment = next(segment for segment in segments if segment.language == "de")
+    assert german_segment.text.startswith(" Jedem")
+
+
+def test_group_chunks_by_language_does_not_drop_unconfident_audio():
+    """Unconfident (lang=None) sub-chunks must always appear in some window."""
+    sub_chunks = [
+        {"start": 0, "end": 160000, "language": "en"},
+        {"start": 160000, "end": 320000, "language": None},
+        {"start": 320000, "end": 480000, "language": None},
+    ]
+    windows = _BatchedPipeline._group_chunks_by_language(
+        sub_chunks, sampling_rate=16000, chunk_length=30.0
+    )
+    total_covered = sum(w["end"] - w["start"] for w in windows)
+    assert total_covered == 30.0
+    assert windows[-1]["end"] == 30.0
+
+
+def test_group_chunks_by_language_emits_distant_none_window():
+    """A distant None span starts its own window instead of being dropped."""
+    sub_chunks = [
+        {"start": 0, "end": 160000, "language": "en"},
+        {"start": 480000, "end": 640000, "language": None},
+        {"start": 960000, "end": 1120000, "language": "de"},
+    ]
+    windows = _BatchedPipeline._group_chunks_by_language(
+        sub_chunks, sampling_rate=16000, chunk_length=30.0
+    )
+    # The None span (30–40s) is too far from the de chunk (60–70s) to merge,
+    # so it must be emitted as its own window rather than dropped.
+    assert len(windows) == 3
+    assert windows[0] == {"start": 0.0, "end": 10.0}
+    assert windows[1] == {"start": 30.0, "end": 40.0}
+    assert windows[2] == {"start": 60.0, "end": 70.0}
 
 
 def test_hotwords(data_dir):


### PR DESCRIPTION
Changes on top of #1466 to prevent conflicts, but it's otherwise unrelated. 

The motivation for this PR is that multilingual mode regularly drops up to 20 seconds of transcription in situations where the language switches, especially in batch mode. In regular mode the problem seems to be less severe. I believe it might be due to some kind of truncation by the model when it's operating in the wrong language.

Improving the accuracy of the detected language in the multilingual output is a nice side effect, at a cost of merely being about three times slower. But I want to emphasize that the main concern is transcriptions that are completely missing.