### PR TITLE
Reset the prompt when multilingual detection changes language

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -1139,6 +1139,7 @@ class WhisperModel:
         seek = seek_clips[clip_idx][0]
         all_tokens = []
         prompt_reset_since = 0
+        previous_language = None
 
         if options.initial_prompt is not None:
             if isinstance(options.initial_prompt, str):
@@ -1194,6 +1195,19 @@ class WhisperModel:
                 language_token, language_probability = results[0][0]
                 language = language_token[2:-2]
 
+                # `previous_tokens` holds text decoded in the previous window's language.
+                # Passed as `<|startofprev|>` context it competes with the language token
+                # set below, so the window can be decoded in the previous language.
+                if previous_language is not None and language != previous_language:
+                    self.logger.debug(
+                        "Reset prompt. Language changed from %s to %s",
+                        previous_language,
+                        language,
+                    )
+                    prompt_reset_since = len(all_tokens)
+                    previous_tokens = []
+
+                previous_language = language
                 tokenizer.language = tokenizer.tokenizer.token_to_id(language_token)
                 tokenizer.language_code = language
 

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 import os
 
 import numpy as np
@@ -155,6 +156,34 @@ def test_stereo_diarization(data_dir):
     segments, _ = model.transcribe(right)
     transcription = "".join(segment.text for segment in segments).strip()
     assert transcription == "The horizon seems extremely distant."
+
+
+def test_multilingual_prompt_reset_on_language_change(data_dir, caplog):
+    """Text carried as prompt context must not survive a language switch.
+
+    https://github.com/SYSTRAN/faster-whisper/issues/1476
+    """
+    model = WhisperModel("tiny")
+
+    audio = decode_audio(os.path.join(data_dir, "multilingual.mp3"))
+    sampling_rate = 16000
+    english = audio[: 30 * sampling_rate]
+    german = audio[30 * sampling_rate : 60 * sampling_rate]
+
+    # Three German windows before the switch, so a prompt has accumulated by the
+    # time English is detected.
+    audio = np.concatenate([german, german, german, english])
+
+    with caplog.at_level(logging.DEBUG, logger="faster_whisper"):
+        segments, _ = model.transcribe(
+            audio,
+            multilingual=True,
+            without_timestamps=True,
+            condition_on_previous_text=True,
+        )
+        list(segments)
+
+    assert "Language changed from de to en" in caplog.text
 
 
 def test_multilingual_transcription(data_dir):


### PR DESCRIPTION
Closes #1476.

`previous_tokens` is bound before the per-window language switch:

```python
previous_tokens = all_tokens[prompt_reset_since:]
...
if options.multilingual:
    results = self.model.detect_language(encoder_output)
    ...
    tokenizer.language_code = language      # language changes here
prompt = self.get_prompt(tokenizer, previous_tokens, ...)   # stale context
```

so the previous window's text travels into the next window as `<|startofprev|>` context and competes with the freshly set language token.

I could not reproduce the wrong-language output on `tiny`, which recovers, so I verified the mechanism directly instead. Instrumenting `get_prompt` on three German windows followed by an English one, built from the existing `tests/data/multilingual.mp3`:

```
before:                          after:
  window 0: lang=de  prev=0        window 0: lang=de  prev=0
  window 1: lang=de  prev=125      window 1: lang=de  prev=125
  window 2: lang=de  prev=250      window 2: lang=de  prev=250
  window 3: lang=en  prev=375      window 3: lang=en  prev=0
```

375 tokens of German ride into the window decoded as English. Same-language conditioning is unchanged, which is the part worth not breaking.

Two details:

- The reset is skipped on the first window, so an `initial_prompt` is not discarded when detection disagrees with the requested language.
- `condition_on_previous_text=False` already resets after every window, which is why it works around this and why `test_multilingual_transcription` passes today: that test sets it explicitly.

The new test asserts the reset fires on the switch. It fails without the change.

`pytest tests/`: 20 passed. `black --check`, `isort --check-only` and `flake8` are clean.