### PR TITLE
Fix crash when model config.json lacks suppress_ids keys

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -686,6 +686,8 @@ class WhisperModel:
                 use_auth_token=use_auth_token,
             )
 
+        self._ensure_suppress_tokens_config(model_path)
+
         self.model = ctranslate2.models.Whisper(
             model_path,
             device=device,
@@ -720,6 +722,44 @@ class WhisperModel:
         )
         self.time_precision = 0.02
         self.max_length = 448
+
+    @staticmethod
+    def _ensure_suppress_tokens_config(model_path: str):
+        """Ensure the model config.json has the keys ctranslate2 expects.
+
+        Custom-converted models may lack ``suppress_ids`` or
+        ``suppress_ids_begin``, which causes ctranslate2 to crash with
+        ``json.exception.type_error.302`` when ``suppress_blank=True`` or
+        ``suppress_tokens=[-1]``.
+        See https://github.com/SYSTRAN/faster-whisper/issues/1251
+        """
+        config_path = os.path.join(model_path, "config.json")
+        if not os.path.isfile(config_path):
+            return
+
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = json.load(f)
+
+        needs_update = False
+        if "suppress_ids_begin" not in config:
+            config["suppress_ids_begin"] = [220, 50257]
+            needs_update = True
+        if "suppress_ids" not in config:
+            config["suppress_ids"] = []
+            needs_update = True
+
+        if needs_update:
+            try:
+                with open(config_path, "w", encoding="utf-8") as f:
+                    json.dump(config, f, indent=2)
+            except OSError:
+                logging.getLogger("faster_whisper").warning(
+                    "Model config at '%s' is missing 'suppress_ids_begin' or "
+                    "'suppress_ids'. Could not write defaults (read-only path). "
+                    "suppress_blank=True may crash; use suppress_blank=False as "
+                    "a workaround.",
+                    config_path,
+                )
 
     @property
     def supported_languages(self) -> List[str]:


### PR DESCRIPTION
## Summary

Fixes #1251

Custom-converted models may lack `suppress_ids_begin` or `suppress_ids` in their `config.json`. When ctranslate2 reads these missing keys internally (triggered by `suppress_blank=True` or `suppress_tokens=[-1]`), it crashes with:

```
RuntimeError: [json.exception.type_error.302] type must be number, but is number
```

This happens because ctranslate2's C++ code iterates over `_model->config["suppress_ids_begin"]` without checking if the key exists — a missing key returns a JSON null, and iterating over null as a number array throws the type error.

## Fix

Added `_ensure_suppress_tokens_config()` in `WhisperModel.__init__` that runs before ctranslate2 loads the model:

- Reads `config.json` and checks for `suppress_ids_begin` and `suppress_ids`
- If missing, writes sensible defaults: `[220, 50257]` for `suppress_ids_begin`, `[]` for `suppress_ids`
- If the model directory is read-only, logs a warning with a workaround (`suppress_blank=False`)

Official HuggingFace models are unaffected (they already have these keys). This only fixes custom-converted models.

## Reproduction

```python
# Remove suppress_ids_begin from any model's config.json, then:
model = WhisperModel("path/to/model", device="cpu")
segments, info = model.transcribe("audio.wav", suppress_blank=True)  # crashes without fix
```

## Test plan

- [x] Broken model (missing keys) + `suppress_blank=True` → now works
- [x] Broken model + `suppress_tokens=[-1]` → now works
- [x] Broken model + `BatchedInferencePipeline` → now works
- [x] Normal model (keys present) → unaffected, no unnecessary writes
- [x] Normal model + `suppress_blank=False` → unaffected