### PR TITLE
fix: disable tqdm's background monitor thread (mitigates #1474)

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -27,6 +27,15 @@ from faster_whisper.vad import (
     get_speech_timestamps,
 )
 
+# tqdm's background monitor thread (used to detect stalled progress bars) has
+# been observed to trigger a rare CPython interpreter race under Python 3.14
+# (an unrelated `__init__` call elsewhere in the process fails with
+# "TypeError: __init__() should return None, not 'NoneType'", see
+# https://github.com/SYSTRAN/faster-whisper/issues/1474). It serves no
+# purpose here, so disable it outright rather than leave a background thread
+# running for the lifetime of the process.
+tqdm.monitor_interval = 0
+
 
 @dataclass
 class Word:


### PR DESCRIPTION
## Investigation

`SpeechTimestampsMap.__init__` (`faster_whisper/vad.py:283`) is plain Python with no return statement, so `TypeError: __init__() should return None, not 'NoneType'` cannot legitimately come from that class — this rules out a bug in that code itself.

The key clue is the second traceback attached to #1474: the *exact same* impossible error, independently raised from CPython's own stdlib (`_weakrefset.WeakSet.copy()` calling `self.__class__(self)`), inside `tqdm`'s `TMonitor` background thread. Two unrelated `__init__` calls hitting the identical, logically-impossible error is strong evidence this is a rare CPython 3.14 interpreter/threading race (most likely GC interacting with a background thread mid-instantiation), not something specific to faster-whisper's code.

I installed Python 3.14.7 (both the standard build and the free-threaded/no-GIL build) and stress-tested this directly: many threads concurrently instantiating `SpeechTimestampsMap`, `_weakrefset.WeakSet`, and a couple of unrelated plain classes, alongside threads forcing continuous `gc.collect()`, for 90s under the free-threaded build (where this kind of race is most likely to surface, since the GIL normally serializes access). I could not reproduce the error in either build. I don't take this as evidence the race doesn't exist — the original report is on Linux (CachyOS) and the failure is, by nature, a rare timing-dependent race that may depend on details I can't replicate here (OS threading behavior, the real C extensions in play - onnxruntime and ctranslate2 - versus my pure-Python stand-in for the class shape, or something else entirely). I could not find a matching upstream CPython issue either. So I want to be explicit: I have not confirmed the exact mechanism, only ruled out that it's a defect in `SpeechTimestampsMap`'s own code.

## What this PR does

`tqdm`'s monitor thread only exists to detect stalled progress bars (`monitor_interval`, documented in `tqdm/std.py`, "set to 0 to disable the thread") and serves no purpose in this library. Disabling it removes one background thread from the process for its entire lifetime, which directly avoids the failure mode demonstrated in that second traceback.

**This is a mitigation, not a confirmed root-cause fix.** Given I couldn't reproduce the underlying race even with the matching Python version, I can't verify this mitigation actually prevents #1474 from recurring - but removing an unnecessary background thread is a safe, real reduction of risk surface regardless, and has no user-visible behavior change (the progress bars themselves are untouched; only stalled-bar *detection* is disabled). Happy to close this if the maintainers would rather wait for a confirmed repro before merging a mitigation.

## Test plan

- [x] `pytest tests/` — 19/19 passing (Python 3.13, Windows)
- [x] `black .` / `isort .` / `flake8 .` — clean on the changed file
- [x] Stress-tested the underlying `__init__`/GC/threading race for 90s on Python 3.14.7, standard and free-threaded builds — no reproduction in either (see Investigation above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)